### PR TITLE
Fix readme with the correct uv commands

### DIFF
--- a/samples/python/agents/google_adk/README.md
+++ b/samples/python/agents/google_adk/README.md
@@ -25,6 +25,6 @@ This agent takes text requests from the client and, if any details are missing, 
 
 4. Run an agent:
     ```bash
-    uv run google_adk/agent
+    uv run agents/google_adk
     ```
 5. Run one of the [client apps](/samples/python/hosts/README.md)


### PR DESCRIPTION
from the `samples/python` directory, the right uv command is `uv run agents/google_adk` for it to run the `__main__.py` file in `google_adk` directory 