### PR TITLE
docs: Update README for CLI sample to correct directory navigation instructions

### DIFF
--- a/samples/python/hosts/cli/README.md
+++ b/samples/python/hosts/cli/README.md
@@ -14,7 +14,7 @@ The client will use streaming if the server supports it.
 
 1. Navigate to the samples directory:
     ```bash
-    cd samples
+    cd samples/python
     ```
 2. Run the example client
     ```


### PR DESCRIPTION
The `uv run` command was written assuming user is in the `samples/python` directory.
And I was not able to run the `cli` host from outside the `python` directory with the command `uv run python/hosts/cli --agent [url]` because its not able to find the `common` module in the `python` directory.

by navigating to the correct directory in the first place `cd samples/python` I was able to run the cli host