### PR TITLE
[Documentation] Clarify apache license in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![image info](images/A2A_banner.png)
-[![Apache License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](./LICENSE)
+[![Apache License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **_An open protocol enabling communication and interoperability between opaque agentic applications._**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![image info](images/A2A_banner.png)
+[![Apache License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](./LICENSE)
 
 **_An open protocol enabling communication and interoperability between opaque agentic applications._**
 
@@ -99,4 +100,4 @@ Future plans include improvements to the protocol itself and enhancements to the
 
 ### **About**
 
-A2A Protocol is an open source project run by Google LLC, under [License](LICENSE) and open to contributions from the entire community.
+A2A Protocol is an open source project run by Google LLC, under [Apache License](LICENSE) and open to contributions from the entire community.


### PR DESCRIPTION
For folks coming into this project, having a clarity on license off the bat is important. This PR adds a Apache 2.0 badge below the header image and clarifies a link to be Apache license. 