### PR TITLE
Instructions for multiagent to work with GOOGLE_API_KEY, for the demo UI to run as expected

### DIFF
--- a/samples/python/hosts/README.md
+++ b/samples/python/hosts/README.md
@@ -6,8 +6,13 @@ Sample apps or agents that are A2A clients that work with A2A servers.
   Command line tool to interact with an A2A server. Specify the server location on the command line. The CLI client looks up the agent card and then performs task completion in a loop based on command line inputs. 
 
 * [Orchestrator Agent](/samples/python/hosts/multiagent)  
-An Agent that speaks A2A and can delegate tasks to remote agents. Built on the Google ADK for demonstration purposes. Includes a "Host Agent" that maintains a collection of "Remote Agents". The Host Agent is itself an agent and can delegate tasks to one or more Remote Agents. Each RemoteAgent is an A2AClient that delegates to an A2A Server. 
+An Agent that speaks A2A and can delegate tasks to remote agents. Built on the Google ADK for demonstration purposes. Includes a "Host Agent" that maintains a collection of "Remote Agents". The Host Agent is itself an agent and can delegate tasks to one or more Remote Agents. Each RemoteAgent is an A2AClient that delegates to an A2A Server. You need to create a `.env` file in this folder with `GOOGLE_API_KEY` environment variable, as it uses an LLM to figure out which remote agent to delegate a task to.
+
+  ```bash
+  cd samples/python/hosts/multiagent
+  echo "GOOGLE_API_KEY=your_api_key_here" > .env
+  ```
 
 * [MultiAgent Web Host](/demo/README.md)  
 *This lives in the [demo](/demo/README.md) directory*  
-A web app that visually shows A2A conversations with multiple agents (using the [Orchestrator Agent](/samples/python/hosts/multiagent)). Will render text, image, and webform artifacts. Has a separate tab to visualize task state and history as well as known agent cards. 
+A web app that visually shows A2A conversations with multiple agents (using the [Orchestrator Agent](/samples/python/hosts/multiagent)). Will render text, image, and webform artifacts. Has a separate tab to visualize task state and history as well as known agent cards. You need to make sure `.env` file exists with your `GOOGLE_API_KEY` in the folder `samples/python/hosts/multiagent` before starting the Web Host.

--- a/samples/python/hosts/multiagent/host_agent.py
+++ b/samples/python/hosts/multiagent/host_agent.py
@@ -4,6 +4,7 @@ import functools
 import json
 import uuid
 import threading
+import os
 from typing import List, Optional, Callable
 
 from google.genai import types
@@ -29,8 +30,12 @@ from common.types import (
     DataPart,
     Part,
     TaskStatusUpdateEvent,
+    MissingAPIKeyError,
 )
 
+from dotenv import load_dotenv
+
+load_dotenv()
 
 class HostAgent:
   """The host agent.
@@ -68,6 +73,8 @@ class HostAgent:
     self.agents = '\n'.join(agent_info)
 
   def create_agent(self) -> Agent:
+    if not os.getenv("GOOGLE_API_KEY"):
+      raise MissingAPIKeyError("GOOGLE_API_KEY environment variable not set.")
     return Agent(
         model="gemini-2.0-flash-001",
         name="host_agent",


### PR DESCRIPTION

- Added instructions for creating a .env file with GOOGLE_API_KEY and why its needed in the hosts README.
- Updated host_agent.py to check for the GOOGLE_API_KEY environment variable and raise an error if not set.