### PR TITLE
Add a placeholder text for agent URL to make it clear to the user, what format is expected.

### DIFF
--- a/demo/ui/pages/agent_list.py
+++ b/demo/ui/pages/agent_list.py
@@ -30,6 +30,7 @@ def agent_list_page(app_state: AppState):
           me.input(
               label="Agent Address",
               on_blur=set_agent_address,
+              placeholder="localhost:10000",
           )
           input_modes_string = ", ".join(state.input_modes)
           output_modes_string = ", ".join(state.output_modes)


### PR DESCRIPTION
I wasted some time, adding URLs of agents with `http://`in the add agents page, and I was not able to add a single running agent and it confused me, and was not sure, if the agents I started seperately can even be added, or if I need to add the `.well-known/agent.json` suffix.

With a placeholder its more clear to the User what is expected in the input box.