### PR TITLE
load environment variables in CrewAI main module

### DIFF
--- a/samples/python/agents/crewai/__main__.py
+++ b/samples/python/agents/crewai/__main__.py
@@ -12,6 +12,10 @@ import logging
 import os
 from task_manager import AgentTaskManager
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 logger = logging.getLogger(__name__)
 
 @click.command()


### PR DESCRIPTION
Even though the env variables are loded in init of `ImageGenerationAgent` class, which is imported by this `__main__.py`, I'm getting `MissingAPIKeyError`

I had to load them in the `__main__.py` to get image generation working with both cli host and the web host.