### PR TITLE
[Docs]: Add demo video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ With *A2A*, agents can show each other their capabilities and negotiate how they
 
 ### **See A2A in Action**
 
-Watch this [demo video](https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4) to see how A2A enables seamless communication between different agent frameworks:
+Watch [this demo video](https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4) to see how A2A enables seamless communication between different agent frameworks.
 
 ### Conceptual Overview
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ With *A2A*, agents can show each other their capabilities and negotiate how they
 
 ### **See A2A in Action**
 
-Watch this [demo video](https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4) to see how A2A enables seamless communication between different agent frameworks:
+Watch this demo video to see how A2A enables seamless communication between different agent frameworks:
 
+<video width="100%" controls>
+  <source src="https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
 
 ### Conceptual Overview
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ With *A2A*, agents can show each other their capabilities and negotiate how they
 
 ### **See A2A in Action**
 
-Watch this demo video to see how A2A enables seamless communication between different agent frameworks:
-
-<video width="100%" controls>
-  <source src="https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+Watch this [demo video](https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4) to see how A2A enables seamless communication between different agent frameworks:
 
 ### Conceptual Overview
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ With *A2A*, agents can show each other their capabilities and negotiate how they
 
 ### **See A2A in Action**
 
-Watch this demo video to see how A2A enables seamless communication between different agent frameworks:
+Watch this [demo video](https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4) to see how A2A enables seamless communication between different agent frameworks:
 
-<video width="100%" controls>
-  <source src="https://storage.googleapis.com/gweb-developer-goog-blog-assets/original_videos/A2A_demo_v4.mp4?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=storage-bucket-access%40gweb-developers-gblog-cms.google.com.iam.gserviceaccount.com%2F20250408%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20250408T174915Z&X-Goog-Expires=86400&X-Goog-SignedHeaders=host&X-Goog-Signature=089d124afdf68c35b97e8042262f686a66681d24b8e21d0586537026faf36598da2ab9ad3bb2d8312e88cba10f443dda33eeb899c500a22b7374a79cf75c4bffd62ab095b45c07dbb4853d796d925123df94bd4b10b36c7bd4dc63aa984784b5a50e2ae7b238457d04b2410682943e2d514c4b530aa82c1a245ee834322f1676a363fa5913a318fe093f7769be17480303aeaee49f7d102ffbad7f9f5ab674386b5b10204d32bc7037d1524617cf21eccb739745a25d6e88cdce7c9fc121923cebbca5d96de0a7014d17953ee7c1c819f3e3ad150ef6d1fbc4730bd8317eb6e5d2c72cb51aebccdc85a2c78b101bc61852b63df6700ba2fed47f10a9ecfa1c16" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
 
 ### Conceptual Overview
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
- Redirecting user to access demo video of A2A implementation.

## Motivation and Context
- This PR solves #42 issue.
- The source link present inside the `<video>` tag return `The provided token has expired. Request signature expired at: 2025-04-09T17:49:15+00:00`.
```bash
<Error>
<Code>ExpiredToken</Code>
<Message>Invalid argument.</Message>
<Details>The provided token has expired. Request signature expired at: 2025-04-09T17:49:15+00:00</Details>
</Error>
```


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation update