### PR TITLE
Fix environment variable loading and documentation for sample

### DIFF
--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -26,11 +26,17 @@ The following example will run the langgraph agent with the python CLI host:
     ```bash
     cd samples/python
     ```
-2. Run an agent:
+2. Create an environment file with your API key:
+
+   ```bash
+   echo "GOOGLE_API_KEY=your_api_key_here" > .env
+   ```
+
+3. Run an agent:
     ```bash
     uv run agents/langgraph
     ```
-3. Run the example client
+4. Run the example client
     ```
     uv run hosts/cli
     ```

--- a/samples/python/agents/langgraph/__main__.py
+++ b/samples/python/agents/langgraph/__main__.py
@@ -3,12 +3,15 @@ from common.types import AgentCard, AgentCapabilities, AgentSkill, MissingAPIKey
 from common.utils.push_notification_auth import PushNotificationSenderAuth
 from agents.langgraph.task_manager import AgentTaskManager
 from agents.langgraph.agent import CurrencyAgent
+from dotenv import load_dotenv
 import click
 import os
 import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+load_dotenv()
 
 @click.command()
 @click.option("--host", "host", default="localhost")

--- a/samples/python/hosts/cli/README.md
+++ b/samples/python/hosts/cli/README.md
@@ -14,7 +14,7 @@ The client will use streaming if the server supports it.
 
 1. Navigate to the samples directory:
     ```bash
-    cd samples
+    cd samples/python
     ```
 2. Run the example client
     ```


### PR DESCRIPTION
# Fix environment variable loading and documentation issues

## Problem
- LangGraph agent fails with `GOOGLE_API_KEY environment variable not set`
- README lacks API key setup instructions
- CLI documentation contains incorrect path (`cd sample`)

## Solution
- Add `load_dotenv()` to [`samples/python/agents/langgraph/__main__.py`](https://claude.ai/samples/python/agents/langgraph/__main__.py)
- Add .env file setup instructions to [`samples/python/README.md`](https://claude.ai/samples/python/README.md)
- Fix path in [`samples/python/hosts/cli/README.md`](https://claude.ai/samples/python/hosts/cli/README.md) to `cd samples/python`

## Result
- Samples now run successfully out-of-the-box
- Improved onboarding experience for new users