### PR TITLE
fix: correct the path in theREADME

### DIFF
--- a/samples/python/agents/google_adk/README.md
+++ b/samples/python/agents/google_adk/README.md
@@ -15,16 +15,17 @@ This agent takes text requests from the client and, if any details are missing, 
 
 1. Navigate to the samples directory:
     ```bash
-    cd samples/python
+    cd samples/python/agents/google_adk
     ```
-2. Create a file named .env under agents/google_adk.
+    
+2. Create an environment file with your API key (sample uses Google Gemini by default):
     ```bash
-    touch agents/google_adk/.env
+    echo "GOOGLE_API_KEY=your_api_key_here" > .env
     ```
-3. Add `GOOGLE_API_KEY` to .env  (sample uses Google Gemini by default)
-
+    
 4. Run an agent:
     ```bash
-    uv run google_adk/agent
+    uv run agent
     ```
+    
 5. Run one of the [client apps](/samples/python/hosts/README.md)

--- a/samples/python/agents/google_adk/README.md
+++ b/samples/python/agents/google_adk/README.md
@@ -17,15 +17,12 @@ This agent takes text requests from the client and, if any details are missing, 
     ```bash
     cd samples/python/agents/google_adk
     ```
-    
 2. Create an environment file with your API key (sample uses Google Gemini by default):
     ```bash
     echo "GOOGLE_API_KEY=your_api_key_here" > .env
     ```
-    
-4. Run an agent:
+3. Run an agent:
     ```bash
-    uv run agent
+    uv run .
     ```
-    
-5. Run one of the [client apps](/samples/python/hosts/README.md)
+4. Run one of the [client apps](/samples/python/hosts/README.md)


### PR DESCRIPTION
Fixed the path to the command line in README.md of demo google_adk to prevent users from copying commands directly and finding errors, so that the command form of demo google_adk is the same as that of langgraph.