### PR TITLE
Fixing "Genkit - Sample Agents" links

### DIFF
--- a/samples/js/src/agents/README.md
+++ b/samples/js/src/agents/README.md
@@ -1,7 +1,7 @@
 ## Genkit - Sample Agents
 
-* [**Movie Info Agent**](/samples/js/src/movie-agent/README.md)  
+* [**Movie Info Agent**](/samples/js/src/agents/movie-agent/README.md)
 This agent uses the TMDB API to answer questions about movies
 
-* [**Coder Agent**](/samples/js/src/coder/README.md)  
+* [**Coder Agent**](/samples/js/src/agents/coder/README.md)  
 This is a simple code-writing agent that emits full code files as artifacts.


### PR DESCRIPTION
This commit fix the path the agents samples source code