### PR TITLE
Add configurable polling to the UI

### DIFF
--- a/demo/ui/components/async_poller.js
+++ b/demo/ui/components/async_poller.js
@@ -7,7 +7,7 @@ class AsyncPoller extends LitElement {
   static properties = {
     triggerEvent: {type: String},
     action: {type: Object},
-    isRunning: {type: Boolean},
+    polling_interval: {type: Number},
   };
 
   render() {
@@ -15,10 +15,13 @@ class AsyncPoller extends LitElement {
   }
 
   firstUpdated() {
+    if (this.polling_interval <= 0) {
+      return;
+    }
     if (this.action) {
       setTimeout(() => {
         this.runTimeout(this.action)
-      }, this.action.duration_seconds * 1000);
+      }, this.polling_interval * 1000);
     }
   }
 
@@ -28,9 +31,11 @@ class AsyncPoller extends LitElement {
         action: action,
       }),
     );
-    setTimeout(() => {
-      this.runTimeout(action);
-    }, action.duration_seconds * 1000);
+    if (this.polling_interval > 0) {
+      setTimeout(() => {
+        this.runTimeout();
+      }, this.polling_interval * 1000);
+    }
   }
 }
 

--- a/demo/ui/components/async_poller.py
+++ b/demo/ui/components/async_poller.py
@@ -40,5 +40,8 @@ def async_poller(
       events={
           "triggerEvent": trigger_event,
       },
-      properties={"action": asdict(action) if action else {}},
+      properties={
+          "polling_interval": action.duration_seconds if action else 1,
+          "action": asdict(action) if action else {}
+      },
   )

--- a/demo/ui/components/header.py
+++ b/demo/ui/components/header.py
@@ -1,5 +1,5 @@
 import mesop as me
-
+from .poller import polling_buttons
 
 @me.content_component
 def header(title: str, icon: str):
@@ -19,4 +19,5 @@ def header(title: str, icon: str):
                 type="headline-5",
                 style=me.Style(font_family="Google Sans"),
             )
-            me.slot()
+        me.slot()
+        polling_buttons()

--- a/demo/ui/components/page_scaffold.py
+++ b/demo/ui/components/page_scaffold.py
@@ -3,6 +3,7 @@ import mesop.labs as mel
 
 from .side_nav import sidenav
 from .async_poller import async_poller, AsyncAction
+from .poller import polling_buttons
 
 from state.state import AppState
 from state.host_agent_service import UpdateAppState
@@ -29,7 +30,11 @@ def page_scaffold():
 
     app_state = me.state(AppState)
     action = (
-        AsyncAction(value=app_state, duration_seconds=1) if app_state else None
+        AsyncAction(
+            value=app_state,
+            duration_seconds=app_state.polling_interval)
+        if app_state
+        else None
     )
     async_poller(
         action=action, trigger_event=refresh_app_state

--- a/demo/ui/components/poller.py
+++ b/demo/ui/components/poller.py
@@ -1,0 +1,49 @@
+import mesop as me
+from state.state import AppState
+from state.host_agent_service import UpdateAppState
+
+@me.content_component
+def polling_buttons():
+    """Polling buttons component"""
+    state = me.state(AppState)
+    with me.box(
+        style=me.Style(
+            display="flex",
+            justify_content="end",
+        )
+    ):
+      me.button_toggle(
+          value=[str(state.polling_interval)],
+        buttons=[
+          me.ButtonToggleButton(label="1s", value="1"),
+          me.ButtonToggleButton(label="5s", value="5"),
+          me.ButtonToggleButton(label="30s", value="30"),
+          me.ButtonToggleButton(label="Disable", value="0")
+        ],
+        multiple=False,
+        hide_selection_indicator=True,
+        disabled=False,
+        on_change=on_change,
+        style=me.Style(
+            margin=me.Margin(bottom=20),
+
+        ),
+      )
+      with me.content_button(
+        type="raised",
+        on_click=force_refresh,
+      ):
+        me.icon("refresh")
+    me.slot()
+
+def on_change(e: me.ButtonToggleChangeEvent):
+  state = me.state(AppState)
+  state.polling_interval = int(e.values[0])
+
+async def force_refresh(e: me.ClickEvent):
+    """Refresh app state event handler"""
+    yield
+    app_state = me.state(AppState)
+    await UpdateAppState(app_state, app_state.current_conversation_id)
+    yield
+

--- a/demo/ui/state/state.py
+++ b/demo/ui/state/state.py
@@ -65,6 +65,7 @@ class AppState:
   completed_forms: dict[str, dict[str, Any] | None] = dataclasses.field(default_factory=dict)
   # This is used to track the message sent to agent with form data
   form_responses: dict[str, str] = dataclasses.field(default_factory=dict)
+  polling_interval: int = 1
 
 @me.stateclass
 class SettingsState:


### PR DESCRIPTION
- Provide present intervals of 1, 5 and 30 seconds as well as a disable
- Show the user message immediately (no polling) regardless of setting
- Provide a force refresh, essential for disabled polling and long polling to get updated