### PR TITLE
fix: Convert generator to list before indexing in ADK agent

### DIFF
--- a/samples/python/agents/google_adk/agent.py
+++ b/samples/python/agents/google_adk/agent.py
@@ -16,12 +16,12 @@ request_ids = set()
 def create_request_form(date: Optional[str] = None, amount: Optional[str] = None, purpose: Optional[str] = None) -> dict[str, Any]:
   """
    Create a request form for the employee to fill out.
-   
+
    Args:
        date (str): The date of the request. Can be an empty string.
        amount (str): The requested amount. Can be an empty string.
        purpose (str): The purpose of the request. Can be an empty string.
-       
+
    Returns:
        dict[str, Any]: A dictionary containing the request form data.
    """
@@ -35,20 +35,20 @@ def create_request_form(date: Optional[str] = None, amount: Optional[str] = None
   }
 
 def return_form(
-    form_request: dict[str, Any],    
+    form_request: dict[str, Any],
     tool_context: ToolContext,
     instructions: Optional[str] = None) -> dict[str, Any]:
   """
    Returns a structured json object indicating a form to complete.
-   
+
    Args:
        form_request (dict[str, Any]): The request form data.
        tool_context (ToolContext): The context in which the tool operates.
-       instructions (str): Instructions for processing the form. Can be an empty string.       
-       
+       instructions (str): Instructions for processing the form. Can be an empty string.
+
    Returns:
        dict[str, Any]: A JSON dictionary for the form response.
-   """  
+   """
   if isinstance(form_request, str):
     form_request = json.loads(form_request)
 
@@ -126,9 +126,9 @@ class ReimbursementAgent:
           state={},
           session_id=session_id,
       )
-    events = self._runner.run(
+    events = list(self._runner.run(
         user_id=self._user_id, session_id=session.id, new_message=content
-    )
+    ))
     if not events or not events[-1].content or not events[-1].content.parts:
       return ""
     return "\n".join([p.text for p in events[-1].content.parts if p.text])


### PR DESCRIPTION
This PR fixes issue #110 where the ADK agent was attempting to index a generator object directly, which is not supported in Python.

## Problem
In the `invoke` method of the `ReimbursementAgent` class, the code was trying to access `events[-1]` where `events` is a generator returned by `self._runner.run()`. Generators don't support indexing, which would cause a TypeError.

## Solution
The fix converts the generator to a list before attempting to index it:
```python
events = list(self._runner.run(
    user_id=self._user_id, session_id=session.id, new_message=content
))