### PR TITLE
fix: Update UI components to respect dark mode theme

### DIFF
--- a/demo/ui/components/chat_bubble.py
+++ b/demo/ui/components/chat_bubble.py
@@ -67,7 +67,7 @@ def chat_box(
                         padding=me.Padding(top=1, left=15, right=15, bottom=1),
                         margin=me.Margin(top=5, left=0, right=0, bottom=5),
                         background=(
-                            "lightgreen" if role == "user" else "lightgrey"
+                            me.theme_var("primary-container") if role == "user" else me.theme_var("secondary-container")
                         ),
                         border_radius=15),
                 )
@@ -98,7 +98,7 @@ def chat_box(
                   padding=me.Padding(top=1, left=15, right=15, bottom=1),
                   margin=me.Margin(top=5, left=0, right=0, bottom=5),
                   background=(
-                      "lightgreen" if role == "agent" else "smokewhite"
+                      me.theme_var("primary-container") if role == "agent" else me.theme_var("secondary-container")
                   ),
                   border_radius=15),
           ):

--- a/demo/ui/components/dialog.py
+++ b/demo/ui/components/dialog.py
@@ -24,7 +24,7 @@ def dialog(is_open: bool):
         ):
             with me.box(
                 style=me.Style(
-                    background="#fff",
+                    background=me.theme_var("background"),
                     border_radius=20,
                     box_sizing="content-box",
                     box_shadow=(

--- a/demo/ui/components/form_render.py
+++ b/demo/ui/components/form_render.py
@@ -102,7 +102,7 @@ def render_form_card(message: StateMessage, data: dict[str, Any] | None):
     style=me.Style(
       padding=me.Padding.all(BOX_PADDING),
       max_width="75vw",
-      background="whitesmoke",
+      background=me.theme_var("surface"),
       border_radius=15,
       margin=me.Margin(top=5, bottom=20, left=5, right=5),
       justify_content=(
@@ -172,7 +172,7 @@ def render_structure(id: str, elements: list[FormElement], instructions: str):
     style=me.Style(
       padding=me.Padding.all(BOX_PADDING),
       max_width="75vw",
-      background="whitesmoke",
+      background=me.theme_var("surface"),
       border_radius=15,
       margin=me.Margin(top=5, bottom=20, left=5, right=5),
       box_shadow=("0 1px 2px 0 rgba(60, 64, 67, 0.3), "


### PR DESCRIPTION
This PR fixes issue #108 where the dark mode in the web UI is not working correctly. Some UI components had hardcoded colors that didn't respect the theme settings.

## Problem
Several UI components had hardcoded background colors like `#fff`, `whitesmoke`, `lightgreen`, and `smokewhite` instead of using theme variables. This caused these components to display with light colors even when dark mode was enabled, creating a poor user experience.

## Changes
1. Updated `dialog.py` to use `me.theme_var("background")` instead of hardcoded `#fff` for dialog backgrounds
2. Updated `form_render.py` to use `me.theme_var("surface")` instead of hardcoded `whitesmoke` for form backgrounds
3. Updated `chat_bubble.py` to use theme variables for chat bubble backgrounds:
   - Changed `lightgreen` and `lightgrey` to `me.theme_var("primary-container")` and `me.theme_var("secondary-container")`
   - Changed `smokewhite` to `me.theme_var("secondary-container")`

## Testing
The changes have been tested by toggling between light and dark modes. All components now properly respect the theme settings, providing a consistent dark mode experience.

## Screenshots
Before:
![Dark mode issue](https://github.com/user-attachments/assets/dc502470-1845-4bb2-980a-b67adc7632a8)

After:
![Screenshot 2025-04-12 at 3 54 13 pm](https://github.com/user-attachments/assets/62069326-300f-4139-8aaa-d22fd276a3ae)

