### PR TITLE
feat: add rejected task state to a2a protocol

### DIFF
--- a/samples/js/src/schema.ts
+++ b/samples/js/src/schema.ts
@@ -96,6 +96,7 @@ export type TaskState =
   | "completed"
   | "canceled"
   | "failed"
+  | "rejected"
   | "unknown";
 
 /**

--- a/samples/python/common/types.py
+++ b/samples/python/common/types.py
@@ -15,6 +15,7 @@ class TaskState(str, Enum):
     COMPLETED = "completed"
     CANCELED = "canceled"
     FAILED = "failed"
+    REJECTED = "rejected"
     UNKNOWN = "unknown"
 
 
@@ -100,7 +101,7 @@ class TaskStatusUpdateEvent(BaseModel):
 
 class TaskArtifactUpdateEvent(BaseModel):
     id: str
-    artifact: Artifact    
+    artifact: Artifact
     metadata: dict[str, Any] | None = None
 
 

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -72,7 +72,7 @@
           },
           "url": {
             "title": "Url",
-            "type": "string"            
+            "type": "string"
           },
           "provider": {
             "anyOf": [
@@ -715,7 +715,7 @@
         },
         "title": "GetTaskPushNotificationResponse",
         "type": "object"
-      },      
+      },
       "GetTaskRequest": {
         "properties": {
           "jsonrpc": {
@@ -1126,7 +1126,7 @@
             },
             "title": "Parts",
             "type": "array"
-          },          
+          },
           "metadata": {
             "anyOf": [
               {
@@ -1192,7 +1192,7 @@
           },
           "token": {
             "title": "Token",
-            "anyOf": [              
+            "anyOf": [
               {
                 "type": "string"
               },
@@ -1271,7 +1271,7 @@
         ],
         "title": "SendTaskRequest",
         "type": "object"
-      },      
+      },
       "SendTaskResponse": {
         "properties": {
           "jsonrpc": {
@@ -1298,7 +1298,7 @@
             "anyOf": [
               {
                 "$ref": "#/$defs/Task"
-              },              
+              },
               {
                 "type": "null"
               }
@@ -1382,7 +1382,7 @@
             "title": "Id"
           },
           "result": {
-            "anyOf": [              
+            "anyOf": [
               {
                 "$ref": "#/$defs/TaskStatusUpdateEvent"
               },
@@ -1570,7 +1570,7 @@
         ],
         "title": "TaskPushNotificationConfig",
         "type": "object"
-      },      
+      },
       "TaskNotCancelableError": {
         "properties": {
           "code": {
@@ -1679,14 +1679,14 @@
             "anyOf": [
               {
                 "type": "integer"
-              },              
+              },
               {
                 "type": "null"
               }
             ],
             "default": null,
             "title": "HistoryLength"
-          },          
+          },
           "metadata": {
             "anyOf": [
               {
@@ -1719,7 +1719,7 @@
           },
           "message": {
             "$ref": "#/$defs/Message"
-          },          
+          },
           "pushNotification": {
             "anyOf": [
               {
@@ -1735,14 +1735,14 @@
             "anyOf": [
               {
                 "type": "integer"
-              },              
+              },
               {
                 "type": "null"
               }
             ],
             "default": null,
             "title": "HistoryLength"
-          },   
+          },
           "metadata": {
             "anyOf": [
               {
@@ -1773,6 +1773,7 @@
           "completed",
           "canceled",
           "failed",
+          "rejected",
           "unknown"
         ],
         "title": "TaskState",
@@ -1992,7 +1993,7 @@
           },
           {
             "$ref": "#/$defs/CancelTaskRequest"
-          },          
+          },
           {
             "$ref": "#/$defs/SetTaskPushNotificationRequest"
           },


### PR DESCRIPTION
This PR adds a new 'rejected' task state to the A2A protocol, addressing issue #104.

## Problem
Currently, the A2A protocol has states for tasks that are completed, canceled, or failed, but there's no way to explicitly indicate that a task was rejected. This makes it difficult to distinguish between tasks that failed due to errors and tasks that were explicitly rejected by the agent.

## Changes
1. Added the "rejected" state to the TaskState enum in the JSON schema (`specification/json/a2a.json`)
2. Added the "rejected" state to the TaskState enum in the Python implementation (`samples/python/common/types.py`)
3. Added the "rejected" state to the TaskState type in the TypeScript implementation (`samples/js/src/schema.ts`)

## Testing
The changes have been tested by:
1. Verifying that the Python implementation correctly defines and uses the "rejected" state
2. Verifying that the TypeScript implementation correctly defines the "rejected" state
3. Validating that the JSON schema remains valid after the changes

## Documentation
No documentation updates were needed as the task states are primarily defined in the schema files that have been updated.