### PR TITLE
Add dark mode (following system preference)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="An open protocol enabling communication and interoperability between opaque agentic applications.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/dark.css" media="(prefers-color-scheme: dark)">
   <!-- index.html -->
 </head>
 <body>


### PR DESCRIPTION
Uses the docsify built-in dark theme

Screenshots:
- system in dark mode:  
![image](https://github.com/user-attachments/assets/6f306f13-c04c-4c15-8182-fef45aac9cf9)
- system in light mode: 
![image](https://github.com/user-attachments/assets/7c2c3d7b-d95e-46e3-8705-08cc7e3ba0c1)

