### PR TITLE
feat(samples): Add go language sample for `A2A` protocol

### DIFF
--- a/samples/go/.gitignore
+++ b/samples/go/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work 

--- a/samples/go/README.md
+++ b/samples/go/README.md
@@ -1,0 +1,186 @@
+# A2A Protocol - Go Sample
+
+This directory contains sample implementations demonstrating the Agent2Agent (A2A) protocol using Go.
+
+## Overview
+
+This sample provides a basic A2A agent implementation, structured into several packages:
+
+- **`schema`**: Go structs representing the A2A JSON-RPC types (`schema/schema.go`).
+- **`store`**: An interface (`TaskStore`) and an in-memory implementation (`InMemoryTaskStore`) for managing task state (`store/memory.go`).
+- **`agent`**: The main A2A HTTP handler (`A2AHandler`) which uses the `TaskStore` and handles JSON-RPC method dispatch (`agent/server.go`). It uses structured logging (`log/slog`).
+- **`main`**: The entry point that initializes logging (`log/slog` with JSON output), the store, and the agent handler, and starts the HTTP server (`main.go`).
+
+## Request Flow Diagram
+
+The following diagram illustrates the typical flow of a request through the sample agent:
+
+```ascii
++---------------------+          +------------------------+          +----------------------+          +---------------------+          +-------------+
+| Client (e.g. curl)  |          | HTTP Server (main.go)  |          | A2AHandler (agent)   |          | TaskStore (store)   |          | Logger (slog)|
++---------------------+          +------------------------+          +----------------------+          +---------------------+          +-------------+
+         |                               |                                   |                               |                         |
+         | POST /a2a (JSON-RPC Req)      |                                   |                               |                         |
+         |------------------------------>|                                   |                               |                         |
+         |                               | ServeHTTP(req)                    |                               |                         |
+         |                               |---------------------------------->|                               |                         |
+         |                               |                                   | Log request received          |                         |
+         |                               |                                   |-------------------------------------------------------->|
+         |                               |                                   | Decode JSON-RPC               |                         |
+         |                               |                                   |-----------------------------\|                         |
+         |                               |                                   |                             | |                         |
+         |                               |                                   | <---- Method Dispatch ------> | |                         |
+         |                               |                                   |                             | |                         |
+         |                               |                                   |  IF tasks/send:             | |                         |
+         |                               |                                   |   Put(task)                 | |                         |
+         |                               |                                   |------------------------------>|                         |
+         |                               |                                   |                             |<| (ok)                  |
+         |                               |                                   |                             |-------------------------|
+         |                               |                                   |   Log task created/completed|                         |
+         |                               |                                   |-------------------------------------------------------->|
+         |                               |                                   |  ELSE IF tasks/get:         | |                         |
+         |                               |                                   |   Get(taskID)               | |                         |
+         |                               |                                   |------------------------------>|                         |
+         |                               |                                   |                             |<| task                  |
+         |                               |                                   |                             |-------------------------|
+         |                               |                                   |   Log task retrieved        |                         |
+         |                               |                                   |-------------------------------------------------------->|
+         |                               |                                   |                             | |                         |
+         |                               |                                   | Encode JSON-RPC Response    | |                         |
+         |                               |                                   |<-----------------------------/ |                         |
+         |                               | response                          |                               |                         |
+         |                               |<----------------------------------|                               |                         |
+         | HTTP Response (JSON-RPC Resp) |                                   |                               |                         |
+         |<------------------------------|                                   |                               |                         |
+         |                               |                                   |                               |                         |
+
+```
+
+## Running the Sample
+
+Follow these steps to run the agent and interact with it:
+
+1.  **Start the Server**:
+
+    - Navigate to the Go sample directory in your terminal:
+      ```bash
+      cd samples/go
+      ```
+    - Run the server:
+      ```bash
+      go run main.go
+      ```
+    - The server will start listening on port 8080 (by default) and output its first structured log message (using `slog` JSON handler):
+      ```json
+      {
+        "time": "YYYY-MM-DDTHH:MM:SS.ffffffZ",
+        "level": "INFO",
+        "msg": "Starting A2A Go sample agent",
+        "address": ":8080",
+        "endpoint": "/a2a"
+      }
+      ```
+      _(Timestamp will vary)_.
+
+2.  **Send a Task (`tasks/send`)**:
+
+    - Open **another terminal window**.
+    - Use `curl` to send a POST request with a `tasks/send` JSON-RPC message:
+      ```bash
+      curl -X POST http://localhost:8080/a2a \
+      -H "Content-Type: application/json" \
+      -d '{
+        "jsonrpc": "2.0",
+        "method": "tasks/send",
+        "params": {
+          "id": "task-123",
+          "message": {
+            "role": "user",
+            "parts": [
+              {
+                "text": "Hello agent!"
+              }
+            ]
+          }
+        },
+        "id": 1
+      }'
+      ```
+    - **Server Logs:** In the _first_ terminal (where the server is running), you will see structured logs related to this request:
+      ```json
+      {"time":"YYYY-MM-DDTHH:MM:SS.ffffffZ","level":"INFO","msg":"Received request","method":"tasks/send","id":1}
+      {"time":"YYYY-MM-DDTHH:MM:SS.ffffffZ","level":"INFO","msg":"Task created and completed","method":"tasks/send","id":1,"task_id":"task-123"}
+      ```
+    - **Curl Output:** In the _second_ terminal (where you ran `curl`), you will receive the JSON-RPC response:
+      ```json
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": {
+          "id": "task-123",
+          "sessionId": null,
+          "status": {
+            "state": "completed",
+            "message": {
+              "role": "agent",
+              "parts": [
+                {
+                  "Type": "text",
+                  "Text": "Hello agent!",
+                  "Metadata": null
+                }
+              ],
+              "metadata": {
+                "echo_response": true
+              }
+            },
+            "timestamp": "YYYY-MM-DDTHH:MM:SS.ffffffZ"
+          },
+          "artifacts": null,
+          "metadata": null
+        }
+      }
+      ```
+      _(Note: Timestamps and exact formatting might vary slightly. Go's default JSON marshaler might add fields like `Type` even if omitted in the struct definition if they aren't explicitly tagged with `omitempty` and have a zero value like `nil` or `""`.)_
+
+3.  **Get Task Status (`tasks/get`)**:
+    - In the _second_ terminal, use `curl` again to send a `tasks/get` request for the task you just created:
+      ```bash
+      curl -X POST http://localhost:8080/a2a \
+      -H "Content-Type: application/json" \
+      -d '{
+        "jsonrpc": "2.0",
+        "method": "tasks/get",
+        "params": {
+          "id": "task-123"
+        },
+        "id": 2
+      }'
+      ```
+    - **Server Logs:** The server terminal will show logs for this request:
+      ```json
+      {"time":"YYYY-MM-DDTHH:MM:SS.ffffffZ","level":"INFO","msg":"Received request","method":"tasks/get","id":2}
+      {"time":"YYYY-MM-DDTHH:MM:SS.ffffffZ","level":"INFO","msg":"Retrieved task","method":"tasks/get","id":2,"task_id":"task-123"}
+      ```
+    - **Curl Output:** The `curl` command will output the same task details retrieved from the agent's store:
+      ```json
+      {
+        "id": 2, // Note the response ID matches the request ID
+        "jsonrpc": "2.0",
+        "result": {
+          "id": "task-123"
+          // ... rest of the task details as shown in the previous step ...
+        }
+      }
+      ```
+
+## Further Development
+
+This sample provides a foundation. Potential extensions include:
+
+- Implementing more A2A methods (e.g., `tasks/cancel`, streaming with `tasks/sendSubscribe`).
+- Adding more sophisticated agent logic beyond a simple echo.
+- Implementing error handling for different scenarios (e.g., invalid part types).
+- Swapping the `InMemoryTaskStore` with a persistent storage implementation.
+- Creating an A2A client implementation in Go.
+- Integrating with specific Go agent frameworks or libraries.

--- a/samples/go/agent/server.go
+++ b/samples/go/agent/server.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/A2A/samples/go/schema"
+	"github.com/google/A2A/samples/go/store"
+)
+
+// A2AHandler handles A2A protocol requests.
+type A2AHandler struct {
+	logger *slog.Logger
+	store  store.TaskStore
+}
+
+// NewA2AHandler creates a new A2AHandler.
+func NewA2AHandler(logger *slog.Logger, store store.TaskStore) *A2AHandler {
+	return &A2AHandler{
+		logger: logger,
+		store:  store,
+	}
+}
+
+// ServeHTTP handles incoming HTTP requests.
+func (h *A2AHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.logger.Warn("Method not allowed", slog.String("method", r.Method), slog.String("path", r.URL.Path))
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.writeJSONRPCError(w, nil, -32700, "Parse error", err.Error())
+		return
+	}
+	defer r.Body.Close()
+
+	var req schema.JSONRPCRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		h.writeJSONRPCError(w, nil, -32700, "Parse error", err.Error())
+		return
+	}
+
+	if req.JSONRPC != "2.0" {
+		h.writeJSONRPCError(w, req.ID, -32600, "Invalid Request", "Invalid JSON-RPC version")
+		return
+	}
+
+	requestLogger := h.logger.With(slog.String("method", req.Method), slog.Any("id", req.ID))
+	requestLogger.Info("Received request")
+
+	switch req.Method {
+	case "tasks/send":
+		h.handleTaskSend(w, req, requestLogger)
+	case "tasks/get":
+		h.handleTaskGet(w, req, requestLogger)
+	default:
+		errMsg := fmt.Sprintf("Method '%s' not supported", req.Method)
+		requestLogger.Warn("Method not found", slog.String("error", errMsg))
+		h.writeJSONRPCError(w, req.ID, -32601, "Method not found", errMsg)
+	}
+}
+
+// handleTaskSend processes tasks/send requests.
+func (h *A2AHandler) handleTaskSend(w http.ResponseWriter, req schema.JSONRPCRequest, logger *slog.Logger) {
+	var params schema.TaskSendParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		logger.Error("Invalid params for tasks/send", slog.String("error", err.Error()))
+		h.writeJSONRPCError(w, req.ID, -32602, "Invalid params", err.Error())
+		return
+	}
+
+	logger = logger.With(slog.String("task_id", params.ID))
+
+	// --- Basic Echo Logic ---
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	responseMessage := schema.Message{
+		Role:     "agent",
+		// IMPORTANT: This is just an echo. A real agent would process the input
+		// (params.Message.Parts) and construct meaningful output parts here.
+		Parts:    params.Message.Parts, // Echo back the input parts
+		Metadata: map[string]interface{}{"echo_response": true},
+	}
+	task := &schema.Task{
+		ID:        params.ID,
+		SessionID: params.SessionID,
+		Status: schema.TaskStatus{
+			State:     schema.TaskStateCompleted, // Immediately complete
+			Message:   &responseMessage,
+			Timestamp: &now,
+		},
+		Metadata: params.Metadata, // Echo metadata
+	}
+	// ------------------------
+
+	h.store.Put(task)
+	logger.Info("Task created and completed")
+
+	resp := schema.JSONRPCResponse{
+		JSONRPCMessage: schema.JSONRPCMessage{
+			JSONRPCMessageIdentifier: schema.JSONRPCMessageIdentifier{ID: req.ID},
+			JSONRPC:                  "2.0",
+		},
+		Result: task, // Return the completed task object
+	}
+	h.writeJSONResponse(w, resp, logger)
+}
+
+// handleTaskGet processes tasks/get requests.
+func (h *A2AHandler) handleTaskGet(w http.ResponseWriter, req schema.JSONRPCRequest, logger *slog.Logger) {
+	var params schema.TaskQueryParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		logger.Error("Invalid params for tasks/get", slog.String("error", err.Error()))
+		h.writeJSONRPCError(w, req.ID, -32602, "Invalid params", err.Error())
+		return
+	}
+
+	logger = logger.With(slog.String("task_id", params.ID))
+
+	task, found := h.store.Get(params.ID)
+	if !found {
+		errMsg := fmt.Sprintf("Task with ID '%s' not found", params.ID)
+		logger.Warn("Task not found", slog.String("error", errMsg))
+		h.writeJSONRPCError(w, req.ID, -32001, "Task not found", errMsg)
+		return
+	}
+
+	logger.Info("Retrieved task")
+
+	resp := schema.JSONRPCResponse{
+		JSONRPCMessage: schema.JSONRPCMessage{
+			JSONRPCMessageIdentifier: schema.JSONRPCMessageIdentifier{ID: req.ID},
+			JSONRPC:                  "2.0",
+		},
+		Result: task, // Return the found task object
+	}
+	h.writeJSONResponse(w, resp, logger)
+}
+
+// writeJSONResponse sends a JSON response.
+func (h *A2AHandler) writeJSONResponse(w http.ResponseWriter, resp interface{}, logger *slog.Logger) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		logger.Error("Error encoding JSON response", slog.String("error", err.Error()))
+		// Attempt to write a minimal error if encoding fails, but might also fail.
+		http.Error(w, `{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error"},"id":null}`, http.StatusInternalServerError)
+	}
+}
+
+// writeJSONRPCError sends a JSON-RPC error response.
+func (h *A2AHandler) writeJSONRPCError(w http.ResponseWriter, id *interface{}, code int, message string, data interface{}) {
+	rpcErr := schema.JSONRPCError{
+		Code:    code,
+		Message: message,
+		Data:    data,
+	}
+	resp := schema.JSONRPCResponse{
+		JSONRPCMessage: schema.JSONRPCMessage{
+			JSONRPCMessageIdentifier: schema.JSONRPCMessageIdentifier{ID: id},
+			JSONRPC:                  "2.0",
+		},
+		Error: &rpcErr,
+	}
+
+	h.logger.Warn("Sending error response",
+		slog.Int("code", code),
+		slog.String("message", message),
+		slog.Any("data", data),
+		slog.Any("id", id),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError) // Often appropriate for RPC errors
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("Error encoding JSON-RPC error response", slog.String("error", err.Error()))
+	}
+}

--- a/samples/go/go.mod
+++ b/samples/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/A2A/samples/go
+
+go 1.24.2

--- a/samples/go/main.go
+++ b/samples/go/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/google/A2A/samples/go/agent"
+	"github.com/google/A2A/samples/go/store"
+)
+
+func main() {
+	port := flag.Int("port", 8080, "Port to listen on")
+	flag.Parse()
+
+	// Initialize structured logger (slog)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil)) // Logs JSON to stdout
+	slog.SetDefault(logger)
+
+	addr := fmt.Sprintf(":%d", *port)
+
+	// Initialize dependencies
+	taskStore := store.NewInMemoryTaskStore()
+	a2aHandler := agent.NewA2AHandler(logger, taskStore)
+
+	// Setup HTTP server
+	mux := http.NewServeMux()
+	mux.Handle("/a2a", a2aHandler) // Endpoint for A2A requests
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	logger.Info("Starting A2A Go sample agent", slog.String("address", addr), slog.String("endpoint", "/a2a"))
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Error("Failed to start server", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+} 

--- a/samples/go/schema/schema.go
+++ b/samples/go/schema/schema.go
@@ -1,0 +1,224 @@
+package schema
+
+import "encoding/json"
+
+// TaskState represents the state of a task.
+// Corresponds to the TaskState enum in the A2A schema.
+type TaskState string
+
+const (
+	TaskStateSubmitted     TaskState = "submitted"
+	TaskStateWorking       TaskState = "working"
+	TaskStateInputRequired TaskState = "input-required"
+	TaskStateCompleted     TaskState = "completed"
+	TaskStateCanceled      TaskState = "canceled"
+	TaskStateFailed        TaskState = "failed"
+	TaskStateUnknown       TaskState = "unknown"
+)
+
+// JSONRPCMessageIdentifier represents the base ID structure for JSON-RPC messages.
+type JSONRPCMessageIdentifier struct {
+	ID *interface{} `json:"id,omitempty"` // Can be string, number, or null
+}
+
+// JSONRPCMessage represents the base structure for all JSON-RPC messages.
+type JSONRPCMessage struct {
+	JSONRPCMessageIdentifier
+	JSONRPC string `json:"jsonrpc"` // Should always be "2.0"
+}
+
+// JSONRPCRequest represents a JSON-RPC request.
+type JSONRPCRequest struct {
+	JSONRPCMessage
+	Method string           `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"` // Use RawMessage to delay parsing
+}
+
+// JSONRPCError represents a JSON-RPC error object.
+type JSONRPCError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// JSONRPCResponse represents a JSON-RPC response.
+type JSONRPCResponse struct {
+	JSONRPCMessage
+	Result interface{}   `json:"result,omitempty"`
+	Error  *JSONRPCError `json:"error,omitempty"`
+}
+
+// --- Core A2A Data Structures ---
+
+// AgentAuthentication defines authentication schemes.
+type AgentAuthentication struct {
+	Schemes     []string `json:"schemes"`
+	Credentials *string  `json:"credentials,omitempty"`
+}
+
+// AgentCapabilities describes agent capabilities.
+type AgentCapabilities struct {
+	Streaming              *bool `json:"streaming,omitempty"`
+	PushNotifications      *bool `json:"pushNotifications,omitempty"`
+	StateTransitionHistory *bool `json:"stateTransitionHistory,omitempty"`
+}
+
+// AgentProvider represents the agent provider.
+type AgentProvider struct {
+	Organization string  `json:"organization"`
+	URL          *string `json:"url,omitempty"`
+}
+
+// AgentSkill defines a specific skill.
+type AgentSkill struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description *string   `json:"description,omitempty"`
+	Tags        []string  `json:"tags,omitempty"`
+	Examples    []string  `json:"examples,omitempty"`
+	InputModes  []string  `json:"inputModes,omitempty"`
+	OutputModes []string  `json:"outputModes,omitempty"`
+}
+
+// AgentCard represents the metadata card for an agent.
+type AgentCard struct {
+	Name               string               `json:"name"`
+	Description        *string              `json:"description,omitempty"`
+	URL                string               `json:"url"`
+	Provider           *AgentProvider       `json:"provider,omitempty"`
+	Version            string               `json:"version"`
+	DocumentationURL   *string              `json:"documentationUrl,omitempty"`
+	Capabilities       AgentCapabilities    `json:"capabilities"`
+	Authentication     *AgentAuthentication `json:"authentication,omitempty"`
+	DefaultInputModes  []string             `json:"defaultInputModes,omitempty"`
+	DefaultOutputModes []string             `json:"defaultOutputModes,omitempty"`
+	Skills             []AgentSkill         `json:"skills"`
+}
+
+// FileContentBase represents the base for file content.
+type FileContentBase struct {
+	Name     *string `json:"name,omitempty"`
+	MimeType *string `json:"mimeType,omitempty"`
+}
+
+// FileContentBytes represents file content as base64 bytes.
+type FileContentBytes struct {
+	FileContentBase
+	Bytes string `json:"bytes"` // Required
+	URI   string `json:"uri,omitempty"` // Should be omitted if bytes is present
+}
+
+// FileContentUri represents file content as a URI.
+type FileContentUri struct {
+	FileContentBase
+	Bytes string `json:"bytes,omitempty"` // Should be omitted if uri is present
+	URI   string `json:"uri"` // Required
+}
+
+// FileContent represents file content (either bytes or URI).
+// Using interface{} because the JSON can be either FileContentBytes or FileContentUri.
+// A consuming agent would use a type switch or type assertion to handle the specific type.
+type FileContent interface{}
+
+// TextPart represents a text part of a message.
+type TextPart struct {
+	Type     string                 `json:"type,omitempty"` // Should be "text"
+	Text     string                 `json:"text"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// FilePart represents a file part of a message.
+type FilePart struct {
+	Type     string                 `json:"type,omitempty"` // Should be "file"
+	File     FileContent            `json:"file"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// DataPart represents a structured data part of a message.
+type DataPart struct {
+	Type     string                 `json:"type,omitempty"` // Should be "data"
+	Data     map[string]interface{} `json:"data"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// Part represents any part of a message (text, file, data).
+// Using interface{} because the JSON can be TextPart, FilePart, or DataPart.
+// A consuming agent would use a type switch or type assertion to determine the actual
+// type of the part and access its specific fields (e.g., part.(TextPart).Text).
+type Part interface{}
+
+// Artifact represents an artifact generated or used by a task.
+type Artifact struct {
+	Name        *string                `json:"name,omitempty"`
+	Description *string                `json:"description,omitempty"`
+	Parts       []Part                 `json:"parts"`
+	Index       *int                   `json:"index,omitempty"`
+	Append      *bool                  `json:"append,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	LastChunk   *bool                  `json:"lastChunk,omitempty"`
+}
+
+// Message represents a message exchanged between user and agent.
+type Message struct {
+	Role     string                 `json:"role"` // "user" or "agent"
+	Parts    []Part                 `json:"parts"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TaskStatus represents the status of a task.
+type TaskStatus struct {
+	State     TaskState `json:"state"`
+	Message   *Message  `json:"message,omitempty"`
+	Timestamp *string   `json:"timestamp,omitempty"` // ISO 8601 format
+}
+
+// Task represents a task being processed.
+type Task struct {
+	ID        string                 `json:"id"`
+	SessionID *string                `json:"sessionId,omitempty"`
+	Status    TaskStatus             `json:"status"`
+	Artifacts []Artifact             `json:"artifacts,omitempty"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TaskHistory represents the message history of a task.
+type TaskHistory struct {
+	MessageHistory []Message `json:"messageHistory,omitempty"`
+}
+
+// PushNotificationConfig defines push notification settings.
+type PushNotificationConfig struct {
+	URL            string                `json:"url"`
+	Token          *string               `json:"token,omitempty"`
+	Authentication *AgentAuthentication `json:"authentication,omitempty"` // Reusing AgentAuthentication for simplicity
+}
+
+// --- Request Parameter Types ---
+
+// TaskSendParams are parameters for the tasks/send method.
+type TaskSendParams struct {
+	ID             string                  `json:"id"`
+	SessionID      *string                 `json:"sessionId,omitempty"`
+	Message        Message                 `json:"message"`
+	PushNotification *PushNotificationConfig `json:"pushNotification,omitempty"`
+	HistoryLength  *int                    `json:"historyLength,omitempty"`
+	Metadata       map[string]interface{}  `json:"metadata,omitempty"`
+}
+
+// TaskIdParams are parameters used for operations needing only a task ID.
+type TaskIdParams struct {
+	ID       string                 `json:"id"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TaskQueryParams are parameters for querying task info by ID.
+type TaskQueryParams struct {
+	TaskIdParams
+	HistoryLength *int `json:"historyLength,omitempty"`
+}
+
+// TaskPushNotificationConfig includes task ID and push config.
+type TaskPushNotificationConfig struct {
+	ID                   string                 `json:"id"`
+	PushNotificationConfig PushNotificationConfig `json:"pushNotificationConfig"`
+} 

--- a/samples/go/store/memory.go
+++ b/samples/go/store/memory.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/google/A2A/samples/go/schema"
+)
+
+// TaskStore defines the interface for storing and retrieving A2A tasks.
+type TaskStore interface {
+	Get(id string) (*schema.Task, bool)
+	Put(task *schema.Task)
+}
+
+// InMemoryTaskStore implements TaskStore using an in-memory map.
+type InMemoryTaskStore struct {
+	mu    sync.RWMutex
+	tasks map[string]*schema.Task
+}
+
+// NewInMemoryTaskStore creates a new InMemoryTaskStore.
+func NewInMemoryTaskStore() *InMemoryTaskStore {
+	return &InMemoryTaskStore{
+		tasks: make(map[string]*schema.Task),
+	}
+}
+
+// Get retrieves a task by its ID.
+func (s *InMemoryTaskStore) Get(id string) (*schema.Task, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	task, found := s.tasks[id]
+	return task, found
+}
+
+// Put stores a task, overwriting if the ID already exists.
+func (s *InMemoryTaskStore) Put(task *schema.Task) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tasks[task.ID] = task
+} 


### PR DESCRIPTION
## Description

Fixes: #49

Provides a starting point for developers wanting to implement A2A agents or clients using Go.

- Adds a new `samples/go` directory containing the sample code.
- Follows a modular structure:
  - `schema`: Defines Go structs matching the A2A JSON-RPC specification.
  - `store`: Provides a `TaskStore` interface and an `InMemoryTaskStore` implementation.
  - `agent`: Contains the core `A2AHandler` implementing a basic "echo" agent for `tasks/send` and `tasks/get` methods over HTTP.
  - `main`: Sets up the HTTP server, initializes dependencies (logger, store, handler).
- Uses the standard Go `log/slog` package for structured JSON logging.
- Includes `go.mod` for dependency management.
