### PR TITLE
Fix Crewai_CLI default connection

### DIFF
--- a/samples/python/agents/crewai/README.md
+++ b/samples/python/agents/crewai/README.md
@@ -69,8 +69,9 @@ sequenceDiagram
 
 5. In a separate terminal, run the A2A client:
 
+   `crewai's default Port is 10001`
    ```bash
-   uv run hosts/cli
+   uv run hosts/cli --agent http://localhost:10001
    ```
 
 ## Features & Improvements

--- a/samples/python/agents/crewai/README.md
+++ b/samples/python/agents/crewai/README.md
@@ -69,9 +69,12 @@ sequenceDiagram
 
 5. In a separate terminal, run the A2A client:
 
-   `crewai's default Port is 10001`
    ```bash
+   # Connect to the agent (specify the agent URL with correct port)
    uv run hosts/cli --agent http://localhost:10001
+   
+   # If you changed the port when starting the agent, use that port instead
+   # uv run hosts/cli --agent http://localhost:YOUR_PORT
    ```
 
 ## Features & Improvements

--- a/samples/python/agents/crewai/__main__.py
+++ b/samples/python/agents/crewai/__main__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.option("--host", "host", default="localhost")
-@click.option("--port", "port", default=10001)
+@click.option("--port", "port", default=10000)
 def main(host, port):
   """Entry point for the A2A + CrewAI Image generation sample."""
   try:

--- a/samples/python/agents/crewai/__main__.py
+++ b/samples/python/agents/crewai/__main__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.option("--host", "host", default="localhost")
-@click.option("--port", "port", default=10000)
+@click.option("--port", "port", default=10001)
 def main(host, port):
   """Entry point for the A2A + CrewAI Image generation sample."""
   try:


### PR DESCRIPTION
## Issue Description
Currently, there is a port inconsistency between the CLI client and the CrewAI agent service. The CrewAI agent was previously using port 10001, while the CLI client in samples/python/hosts/cli is configured to use port 10000. This inconsistency causes connection failures when trying to use the CLI client with the CrewAI agent.

## Solution
~~Standardize the port usage across both components to use port 10000 consistently. This change ensures that the CLI client can connect to the CrewAI agent service without manual port configuration.~~

I've updated the documentation in `samples/python/agents/crewai/README.md` to explicitly specify the correct agent URL when running the CLI client


## Changes Made
~~- Modified the CrewAI agent to use port 10000 by default (`as seen in samples/python/agents/crewai/__main__.py`)~~
~~- Verified that the CLI client is already configured to use port 10000~~
```bash
   # Connect to the agent (specify the agent URL with correct port)
   uv run hosts/cli --agent http://localhost:10001
   # If you changed the port when starting the agent, use that port instead
   # uv run hosts/cli --agent http://localhost:YOUR_PORT
```

## Testing
Verified that the CLI client can successfully connect to the CrewAI agent service after this change.