### PR TITLE
refactor/fix: ADKHostManager Reduce cognitive complexity, test and fix defect

### DIFF
--- a/demo/ui/service/server/adk_host_manager.py
+++ b/demo/ui/service/server/adk_host_manager.py
@@ -393,8 +393,10 @@ class ADKHostManager(ApplicationManager):
         ))
       elif part.file_data:
         parts.append(FilePart(
-            uri=part.file_data.file_uri,
-            mimeType=part.file_data.mime_type
+            file=FileContent(
+                uri=part.file_data.file_uri,
+                mimeType=part.file_data.mime_type
+            )
         ))
       # These aren't managed by the A2A message structure, these are internal
       # details of ADK, we will simply flatten these to json representations.
@@ -407,38 +409,7 @@ class ADKHostManager(ApplicationManager):
       elif part.function_call:
         parts.append(DataPart(data=part.function_call.model_dump()))
       elif part.function_response:
-        # Unnest response
-        try:
-          for p in part.function_response.response['result']:
-            if isinstance(p, str):
-              parts.append(TextPart(text=p))
-            elif isinstance(p, dict):
-              if 'type' in p and p['type'] == 'file':
-                parts.append(FilePart(**p))
-              else:
-                parts.append(DataPart(data=p))
-            elif isinstance(p, DataPart):
-              # If there is an artifact in the response, fetch it and add to parts.
-              if('artifact-file-id' in p.data):
-                file_part = self._artifact_service.load_artifact(user_id=self.user_id,
-                                                              session_id=conversation_id,
-                                                              app_name=self.app_name,
-                                                              filename = p.data['artifact-file-id'])
-                file_data = file_part.inline_data
-                base64_data = base64.b64encode(file_data.data).decode('utf-8')
-                parts.append(FilePart(
-                  file=FileContent(
-                      bytes=base64_data, mimeType=file_data.mime_type, name='artifact_file'
-                  )
-                ))
-              else:
-                parts.append(DataPart(data=p.data))
-            else:
-              # Not sure what this is, treat it like a json string.
-              parts.append(TextPart(text=json.dumps(p)))
-        except Exception as e:
-          print("Couldn't convert to messages:", e)
-          parts.append(DataPart(data=part.function_response.model_dump()))
+        parts.extend(self._handle_function_response(part, conversation_id))
       else:
         raise ValueError("Unexpected content, unknown type")
     return Message(
@@ -446,6 +417,39 @@ class ADKHostManager(ApplicationManager):
         parts=parts,
         metadata={'conversation_id': conversation_id},
     )
+
+  def _handle_function_response(self, part: types.Part, conversation_id: str) -> list[Part]:
+    parts = []
+    try:
+      for p in part.function_response.response['result']:
+        if isinstance(p, str):
+          parts.append(TextPart(text=p))
+        elif isinstance(p, dict):
+          if 'type' in p and p['type'] == 'file':
+            parts.append(FilePart(**p))
+          else:
+            parts.append(DataPart(data=p))
+        elif isinstance(p, DataPart):
+          if 'artifact-file-id' in p.data:
+            file_part = self._artifact_service.load_artifact(user_id=self.user_id,
+                                                          session_id=conversation_id,
+                                                          app_name=self.app_name,
+                                                          filename = p.data['artifact-file-id'])
+            file_data = file_part.inline_data
+            base64_data = base64.b64encode(file_data.data).decode('utf-8')
+            parts.append(FilePart(
+              file=FileContent(
+                  bytes=base64_data, mimeType=file_data.mime_type, name='artifact_file'
+              )
+            ))
+          else:
+            parts.append(DataPart(data=p.data))
+        else:
+          parts.append(TextPart(text=json.dumps(p)))
+    except Exception as e:
+      print("Couldn't convert to messages:", e)
+      parts.append(DataPart(data=part.function_response.model_dump()))
+    return parts
 
 def get_message_id(m: Message | None) -> str  | None:
   if not m or not m.metadata or 'message_id' not in m.metadata:

--- a/demo/ui/tests/test_adk_host_manager.py
+++ b/demo/ui/tests/test_adk_host_manager.py
@@ -1,0 +1,162 @@
+import unittest
+from typing import List, Any
+from service.server.adk_host_manager import ADKHostManager
+from google.genai import types
+from common.types import TextPart, FilePart, DataPart
+
+
+class ADKHostManagerTest(unittest.TestCase):
+  """Tests for ADKHostManager class.
+
+  This test suite verifies the conversion of ADK content to message format,
+  handling various content types including text, files, data, and function responses.
+  """
+
+  def setUp(self) -> None:
+    """Set up test fixtures."""
+    self.manager = ADKHostManager()
+    self.conversation_id = "test_conversation"
+
+  def test_adk_content_to_message_text(self) -> None:
+    """Test converting ADK content with text part to message."""
+    part = types.Part()
+    part.text = "Hello"
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1, "Message should have exactly one part")
+    self.assertIsInstance(message.parts[0], TextPart, "Part should be a TextPart")
+    self.assertEqual(message.parts[0].text, "Hello", "Text content should match")
+    self.assertEqual(message.role, "user", "Role should be preserved")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id,
+                    "Conversation ID should be preserved")
+
+  def test_adk_content_to_message_file(self):
+    """Test converting ADK content with file part to message."""
+    part = types.Part()
+    part.file_data = types.FileData(file_uri="gs://test-bucket/test.txt", mime_type="text/plain")
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], FilePart)
+    self.assertEqual(message.parts[0].type, "file")
+    self.assertEqual(message.parts[0].file.uri, "gs://test-bucket/test.txt")
+    self.assertEqual(message.parts[0].file.mimeType, "text/plain")
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_data(self):
+    """Test converting ADK content with data part to message."""
+    part = types.Part()
+    part.text = '{"key": "value"}'
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.parts[0].data, {"key": "value"})
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_function_response(self):
+    """Test converting ADK content with function response to message."""
+    part = types.Part()
+    part.function_response = types.FunctionResponse(
+        name="test_function",
+        response={"result": [{"type": "text", "text": "Hello"}]}
+    )
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.parts[0].data, {"type": "text", "text": "Hello"})
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_function_response_error(self):
+    """Test error handling when converting function response to message."""
+    part = types.Part()
+    part.function_response = types.FunctionResponse(
+        name="test_function",
+        response={"result": None}
+    )
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 1)
+    self.assertIsInstance(message.parts[0], DataPart)
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_empty_parts(self):
+    """Test converting ADK content with empty parts to message."""
+    content = types.Content(parts=[], role="user")
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 0)
+    self.assertEqual(message.role, "user")
+    self.assertEqual(message.metadata["conversation_id"], self.conversation_id)
+
+  def test_adk_content_to_message_unknown_type(self):
+    """Test handling unknown content type in ADK content."""
+    part = types.Part()
+    content = types.Content(
+        parts=[part],
+        role="user"
+    )
+    with self.assertRaisesRegex(ValueError, "Unexpected content, unknown type"):
+      self.manager.adk_content_to_message(content, self.conversation_id)
+
+  def test_adk_content_to_message_multiple_files(self) -> None:
+    """Test converting ADK content with multiple file parts to message."""
+    file1 = types.Part()
+    file1.file_data = types.FileData(file_uri="gs://test-bucket/file1.txt", mime_type="text/plain")
+    
+    file2 = types.Part()
+    file2.file_data = types.FileData(file_uri="gs://test-bucket/file2.jpg", mime_type="image/jpeg")
+    
+    content = types.Content(
+        parts=[file1, file2],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 2, "Message should have two parts")
+    self.assertIsInstance(message.parts[0], FilePart, "First part should be a FilePart")
+    self.assertIsInstance(message.parts[1], FilePart, "Second part should be a FilePart")
+    self.assertEqual(message.parts[0].file.uri, "gs://test-bucket/file1.txt")
+    self.assertEqual(message.parts[1].file.uri, "gs://test-bucket/file2.jpg")
+
+  def test_adk_content_to_message_mixed_content(self) -> None:
+    """Test converting ADK content with mixed content types to message."""
+    text_part = types.Part()
+    text_part.text = "Hello"
+    
+    file_part = types.Part()
+    file_part.file_data = types.FileData(file_uri="gs://test-bucket/test.txt", mime_type="text/plain")
+    
+    data_part = types.Part()
+    data_part.text = '{"key": "value"}'
+    
+    content = types.Content(
+        parts=[text_part, file_part, data_part],
+        role="user"
+    )
+    message = self.manager.adk_content_to_message(content, self.conversation_id)
+    self.assertEqual(len(message.parts), 3, "Message should have three parts")
+    self.assertIsInstance(message.parts[0], TextPart, "First part should be TextPart")
+    self.assertIsInstance(message.parts[1], FilePart, "Second part should be FilePart")
+    self.assertIsInstance(message.parts[2], DataPart, "Third part should be DataPart")
+
+if __name__ == "__main__":
+  unittest.main() 


### PR DESCRIPTION
- Refactored ADKHostManager to reduce cognitive complexity in function response handling, the original function now has a uniform approach to appending data parts
    - Code extracted to reduce complexity keeps original intact
    - Removed a defect in FilePart instantiation where direct uri/mimeType assignment was not supported
- Added test suite in demo/ui/tests for ADKHostManager
- Added test cases for more coverage of the `adk_content_to_message` function