### PR TITLE
fix: missing ID field in StateEvent conversion

### DIFF
--- a/demo/ui/state/host_agent_service.py
+++ b/demo/ui/state/host_agent_service.py
@@ -176,6 +176,7 @@ def convert_event_to_state(event: Event) -> StateEvent:
       conversation_id=extract_message_conversation(event.content),
       actor=event.actor,
       role=event.content.role,
+      id=event.id,
       content=extract_content(event.content.parts),
   )
 
@@ -232,4 +233,3 @@ def extract_conversation_id(task: Task) -> str:
     if a.metadata and 'conversation_id' in a.metadata:
       return a.metadata['conversation_id']
   return ""
-


### PR DESCRIPTION
Noticed that event IDs were not being rendered in the demo app's event list.

This PR adds the event ID to the StateEvent constructor in convert_event_to_state() function by including `id=event.id`. This ensures the ID field is properly populated when events are displayed in the event viewer table.

## Screenshots

### Before
![Screenshot from 2025-04-14 14-59-07](https://github.com/user-attachments/assets/82d0820a-420d-4ef2-995a-4d997c9de277)

### After
![Screenshot from 2025-04-14 14-56-10](https://github.com/user-attachments/assets/f0760510-db8a-4640-99d1-dc3429aae78c)
