### PR TITLE
Add history array to Task schema definition

### DIFF
--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -1533,6 +1533,21 @@
             "default": null,
             "title": "Artifacts"
           },
+          "history": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/$defs/Message"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "History"
+          },
           "metadata": {
             "anyOf": [
               {


### PR DESCRIPTION
This PR adds Message history to the Task schema definition so that the schema definition matches the technical documentation and example code.

The `tasks/get` input, `TaskQueryParams`, accepts `historyLength` as an integer parameter, which is documented to return the `last N items of history ... which will include all Messages, in order, sent by client and server`. Adding the History field to the Task definition makes this explicit.

## Technical Documentation
[Task Definition](https://google.github.io/A2A/#/documentation?id=task)
```
interface Task {
  id: string; // unique identifier for the task
  sessionId: string; // client-generated id for the session holding the task.
  status: TaskStatus; // current status of the task
  history?: Message[];
  artifacts?: Artifact[]; // collection of artifacts created by the agent.
  metadata?: Record<string, any>; // extension metadata
}
```

[Get a Task Example](https://google.github.io/A2A/#/documentation?id=get-a-task)
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "id": "de38c76d-d54c-436c-8b9f-4c2703648d64",
    "sessionId": "c295ea44-7543-4f78-b524-7a38915ad6e4",
    "status": {
      "state": "completed"
    },
    "artifacts": [{
      "parts": [{
        "type":"text",
        "text":"Why did the chicken cross the road? To get to the other side!"
      }]
    }],
    "history":[
      {
        "role": "user",
        "parts": [
          {
            "type": "text",
            "text": "tell me a joke"
          }
        ]
      }
    ],
    "metadata": {}
  }
}
```

## Python Models

[Task](https://github.com/google/A2A/blob/47b436f3d469f1763a982518cfe3fcc17a6d1818/samples/python/common/types.py#L90)
```python
class Task(BaseModel):
    id: str
    sessionId: str | None = None
    status: TaskStatus
    artifacts: List[Artifact] | None = None
    history: List[Message] | None = None
    metadata: dict[str, Any] | None = None
```
