### PR TITLE
Implement /agent-card endpoint presented in client.ts

### DIFF
--- a/samples/python/common/server/server.py
+++ b/samples/python/common/server/server.py
@@ -46,6 +46,9 @@ class A2AServer:
         self.app.add_route(
             "/.well-known/agent.json", self._get_agent_card, methods=["GET"]
         )
+        self.app.add_route(
+            "/agent-card", self._get_agent_card, methods=["GET"]
+        )
 
     def start(self):
         if self.agent_card is None:


### PR DESCRIPTION
In file /samples/js/src/client/client.ts there are an agentCard method that triggers a GET request trying to retrieve this data. But from the server-side it's defined only in /.well-known/agent.json. So we need to additionally implement the same method through endpoint compatible with specification