### PR TITLE
Part (TextPart | FilePart | DataPart) type property should't be optional

### DIFF
--- a/samples/js/src/client/README.md
+++ b/samples/js/src/client/README.md
@@ -28,7 +28,7 @@ async function run() {
     const taskId = uuidv4();
     const sendParams: TaskSendParams = {
       id: taskId,
-      message: { role: "user", parts: [{ text: "Hello, agent!" }] },
+      message: { role: "user", parts: [{ text: "Hello, agent!", type: "text" }] },
     };
     // Method now returns Task | null directly
     const taskResult: Task | null = await client.sendTask(sendParams);
@@ -67,7 +67,7 @@ async function streamTask() {
     // Construct just the params
     const streamParams: TaskSendParams = {
       id: streamingTaskId,
-      message: { role: "user", parts: [{ text: "Stream me some updates!" }] },
+      message: { role: "user", parts: [{ text: "Stream me some updates!", type: "text" }] },
     };
     // Pass only params to the client method
     const stream = client.sendTaskSubscribe(streamParams);

--- a/samples/js/src/schema.ts
+++ b/samples/js/src/schema.ts
@@ -310,7 +310,7 @@ export type FileContent = FileContentBytes | FileContentUri;
  * Represents a part of a message containing text content.
  */
 export interface TextPart {
-  type?: "text";
+  type: "text";
 
   /**
    * The text content.
@@ -330,7 +330,7 @@ export interface FilePart {
   /**
    * Type identifier for this part.
    */
-  type?: "file";
+  type: "file";
 
   /**
    * The file content, provided either inline or via URI.
@@ -350,7 +350,7 @@ export interface DataPart {
   /**
    * Type identifier for this part.
    */
-  type?: "data";
+  type: "data";
 
   /**
    * The structured data content as a JSON object.


### PR DESCRIPTION
When we're doing requests between TypeScript client and Python server there are some problem related to types:

```typescript
Part = TextPart | FilePart | DataPart 
```
in a client side contains an optional property type that doesn't go when doing request to a backend.

But on a Python server side there are a strict type validation

```python
Part = Annotated[Union[TextPart, FilePart, DataPart], Field(discriminator="type")]
```

That throws an exception when type is not provided 

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32600,
    "message": "Request payload validation error",
    "data": [
      {
        "type": "union_tag_not_found",
        "loc": [
          "tasks/send",
          "params",
          "message",
          "parts",
          0
        ],
        "msg": "Unable to extract tag using discriminator 'type'",
        "input": {
          "text": "hi"
        },
        "ctx": {
          "discriminator": "'type'"
        },
        "url": "https://errors.pydantic.dev/2.10/v/union_tag_not_found"
      }
    ]
  }
}
```
So this is why we need to make it required. Also in a python side this field is not optional 

```python
class TextPart(BaseModel):
    type: Literal["text"] = "text"
    text: str
    metadata: dict[str, Any] | None = None
```