### PR TITLE
Fix error: invoking agent: 'generator' object is not subscriptable

### DIFF
--- a/samples/python/agents/google_adk/agent.py
+++ b/samples/python/agents/google_adk/agent.py
@@ -126,9 +126,9 @@ class ReimbursementAgent:
           state={},
           session_id=session_id,
       )
-    events = self._runner.run(
+    events = list(self._runner.run(
         user_id=self._user_id, session_id=session.id, new_message=content
-    )
+    ))
     if not events or not events[-1].content or not events[-1].content.parts:
       return ""
     return "\n".join([p.text for p in events[-1].content.parts if p.text])


### PR DESCRIPTION
I had this type of exception in my local sources while running this ADK example

```json
INFO:common.server.task_manager:Upserting task b7ebdb35-a1ad-4b57-920e-4112b69b2a50 ERROR:task_manager:Error invoking agent: 'generator' object is not subscriptable ERROR:common.server.server:Unhandled exception: Error invoking agent: 'generator' object is not subscriptable
INFO:     ::1:60297 - "POST / HTTP/1.1" 400 Bad Request
```

And actually the run method signature is

```python
def run(
      self,
      *,
      user_id: str,
      session_id: str,
      new_message: types.Content,
      run_config: RunConfig = RunConfig(),
  ) -> Generator[Event, None, None]:
```

So it returns the Generator object which is not subscriptable as it is trying to be in this code example

Fix me if there is a easier solution but this approach helped me to run E2E implementation with my custom UI in TypeScript and agent made with Python