### PR TITLE
chore: link to uv docs in READMEs

### DIFF
--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -14,7 +14,7 @@ Host applications that use the A2AClient. Includes a CLI which shows simple task
 ## Prerequisites
 
 - Python 3.13 or higher
-- UV
+- [UV](https://docs.astral.sh/uv/)
 
 ## Running the Samples
 

--- a/samples/python/agents/crewai/README.md
+++ b/samples/python/agents/crewai/README.md
@@ -32,7 +32,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Python 3.12 or higher
-- UV package manager (recommended)
+- [UV](https://docs.astral.sh/uv/) package manager (recommended)
 - Google API Key (for Gemini access)
 
 ## Setup & Running

--- a/samples/python/agents/google_adk/README.md
+++ b/samples/python/agents/google_adk/README.md
@@ -7,7 +7,7 @@ This agent takes text requests from the client and, if any details are missing, 
 ## Prerequisites
 
 - Python 3.9 or higher
-- UV
+- [UV](https://docs.astral.sh/uv/)
 - Access to an LLM and API Key
 
 

--- a/samples/python/agents/langgraph/README.md
+++ b/samples/python/agents/langgraph/README.md
@@ -51,7 +51,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Python 3.13 or higher
-- UV
+- [UV](https://docs.astral.sh/uv/)
 - Access to an LLM and API Key
 
 ## Setup & Running

--- a/samples/python/agents/llama_index_file_chat/README.md
+++ b/samples/python/agents/llama_index_file_chat/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Python 3.12 or higher
-- UV
+- [UV](https://docs.astral.sh/uv/)
 - Access to an LLM and API Key (Current code assumes using Google GenAI API)
 - A LlamaParse API key ([get one for free](https://cloud.llamaindex.ai))
 

--- a/samples/python/agents/semantickernel/README.md
+++ b/samples/python/agents/semantickernel/README.md
@@ -41,7 +41,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Python 3.10 or higher
-- uv
+- [uv](https://docs.astral.sh/uv/)
 - Valid OpenAI/Azure OpenAI or other LLM credentials (depending on your SK setup). See [here](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/?tabs=csharp-AzureOpenAI%2Cpython-AzureOpenAI%2Cjava-AzureOpenAI&pivots=programming-language-python#creating-a-chat-completion-service) for more details about Semantic Kernel AI connectors that are used with a ChatCompletionAgent.
 - Access to a Frankfurter API key (optional, or you can call the free endpoint)
 


### PR DESCRIPTION
Adding links to [uv](https://docs.astral.sh/uv/) official docs in
READMEs for those who do not have it installed.