### PR TITLE
Refined HostAgent logic (implement register_remote_agent + some code cleanup)

### DIFF
--- a/samples/python/hosts/multiagent/host_agent.py
+++ b/samples/python/hosts/multiagent/host_agent.py
@@ -48,23 +48,23 @@ class HostAgent:
     self.remote_agent_connections: dict[str, RemoteAgentConnections] = {}
     self.cards: dict[str, AgentCard] = {}
     for address in remote_agent_addresses:
-      card_resolver = A2ACardResolver(address)
-      card = card_resolver.get_agent_card()
-      remote_connection = RemoteAgentConnections(card)
-      self.remote_agent_connections[card.name] = remote_connection
-      self.cards[card.name] = card
-    agent_info = []
-    for ra in self.list_remote_agents():
-      agent_info.append(json.dumps(ra))
-    self.agents = '\n'.join(agent_info)
+        self.register_remote_agent(address)
 
   def register_agent_card(self, card: AgentCard):
     remote_connection = RemoteAgentConnections(card)
     self.remote_agent_connections[card.name] = remote_connection
     self.cards[card.name] = card
+    self._refresh_agent_info()
+
+  def register_remote_agent(self, remote_agent_address: str):
+    card_resolver = A2ACardResolver(remote_agent_address)
+    card = card_resolver.get_agent_card()
+    self.register_agent_card(card)
+
+  def _refresh_agent_info(self):
     agent_info = []
     for ra in self.list_remote_agents():
-      agent_info.append(json.dumps(ra))
+        agent_info.append(json.dumps(ra))
     self.agents = '\n'.join(agent_info)
 
   def create_agent(self) -> Agent:


### PR DESCRIPTION
With my pull request it's possible to register remote agent in HostAgent not only by AgentCard but also with a remote address which is a very consistent improvement considering fact that constructor is getting remote_agent_addresses as argument and not agent cards. So when you need to add agent you'll have to use 

```python
card_resolver = A2ACardResolver(remote_agent_address)
card = card_resolver.get_agent_card()
self.register_agent_card(card)
```

Which is again really problematic and inconsistent. And my improvement will fix it and make code more structured without duplicates that it contained before