### PR TITLE
chore(deps): add anyio dependency to pyproject.toml

### DIFF
--- a/samples/python/agents/google_adk/pyproject.toml
+++ b/samples/python/agents/google_adk/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "a2a-samples",
+    "anyio>=4.9.0",
     "click>=8.1.8",
     "google-adk>=0.0.3",
     "google-genai>=1.9.0",


### PR DESCRIPTION
This commit adds the anyio library as a dependency with a minimum version of 4.9.0. The addition is necessary to ensure compatibility with asynchronous operations in the project, which rely on anyio for managing asynchronous tasks and concurrency.

Fix #243