### PR TITLE
use e.value instead of e.values[0]

### DIFF
--- a/demo/ui/components/poller.py
+++ b/demo/ui/components/poller.py
@@ -38,7 +38,7 @@ def polling_buttons():
 
 def on_change(e: me.ButtonToggleChangeEvent):
   state = me.state(AppState)
-  state.polling_interval = int(e.values[0])
+  state.polling_interval = int(e.value)
 
 async def force_refresh(e: me.ClickEvent):
     """Refresh app state event handler"""


### PR DESCRIPTION
There is already a property as shortcut for returning a single value.
```
@property
  def value(self):
    """Shortcut for returning a single value."""
    if not self.values:
      return ""
    return self.values[0]
```