### PR TITLE
Update the Task Manager in the Google ADK sample to be reusable

### DIFF
--- a/samples/python/agents/google_adk/agent.py
+++ b/samples/python/agents/google_adk/agent.py
@@ -8,6 +8,7 @@ from google.adk.memory.in_memory_memory_service import InMemoryMemoryService
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
+from task_manager import AgentWithTaskManager
 
 # Local cache of created request_ids for demo purposes.
 request_ids = set()
@@ -96,7 +97,7 @@ def reimburse(request_id: str) -> dict[str, Any]:
   return {"request_id": request_id, "status": "approved"}
 
 
-class ReimbursementAgent:
+class ReimbursementAgent(AgentWithTaskManager):
   """An agent that handles reimbursement requests."""
 
   SUPPORTED_CONTENT_TYPES = ["text", "text/plain"]
@@ -112,66 +113,8 @@ class ReimbursementAgent:
         memory_service=InMemoryMemoryService(),
     )
 
-  def invoke(self, query, session_id) -> str:
-    session = self._runner.session_service.get_session(
-        app_name=self._agent.name, user_id=self._user_id, session_id=session_id
-    )
-    content = types.Content(
-        role="user", parts=[types.Part.from_text(text=query)]
-    )
-    if session is None:
-      session = self._runner.session_service.create_session(
-          app_name=self._agent.name,
-          user_id=self._user_id,
-          state={},
-          session_id=session_id,
-      )
-    events = list(self._runner.run(
-        user_id=self._user_id, session_id=session.id, new_message=content
-    ))
-    if not events or not events[-1].content or not events[-1].content.parts:
-      return ""
-    return "\n".join([p.text for p in events[-1].content.parts if p.text])
-
-  async def stream(self, query, session_id) -> AsyncIterable[Dict[str, Any]]:
-    session = self._runner.session_service.get_session(
-        app_name=self._agent.name, user_id=self._user_id, session_id=session_id
-    )
-    content = types.Content(
-        role="user", parts=[types.Part.from_text(text=query)]
-    )
-    if session is None:
-      session = self._runner.session_service.create_session(
-          app_name=self._agent.name,
-          user_id=self._user_id,
-          state={},
-          session_id=session_id,
-      )
-    async for event in self._runner.run_async(
-        user_id=self._user_id, session_id=session.id, new_message=content
-    ):
-      if event.is_final_response():
-        response = ""
-        if (
-            event.content
-            and event.content.parts
-            and event.content.parts[0].text
-        ):
-          response = "\n".join([p.text for p in event.content.parts if p.text])
-        elif (
-            event.content
-            and event.content.parts
-            and any([True for p in event.content.parts if p.function_response])):
-          response = next((p.function_response.model_dump() for p in event.content.parts))
-        yield {
-            "is_task_complete": True,
-            "content": response,
-        }
-      else:
-        yield {
-            "is_task_complete": False,
-            "updates": "Processing the reimbursement request...",
-        }
+  def get_processing_message(self) -> str:
+      return "Processing the reimbursement request..."
 
   def _build_agent(self) -> LlmAgent:
     """Builds the LLM agent for the reimbursement agent."""


### PR DESCRIPTION
This commit decouples the `TaskManager` in `samples/python/agents/google_adk` to be reusable by all Google ADK samples.

**Note:** This could potentially be refactored into a Google ADK specific `common` directory.