### PR TITLE
Update authn/authz to mirror OpenAPI Security Schemes/Requirements

### DIFF
--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -72,9 +72,6 @@
           "capabilities": {
             "$ref": "#/$defs/AgentCapabilities"
           },
-          "authentication": {
-            "$ref": "#/$defs/AgentAuthentication"
-          },
           "defaultInputModes": {
             "default": [
               "text"
@@ -94,6 +91,18 @@
             },
             "title": "Defaultoutputmodes",
             "type": "array"
+          },
+          "securitySchemes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/$defs/SecurityScheme"
+            }
+          },
+          "security": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/SecurityRequirement"
+            }
           },
           "skills": {
             "items": {
@@ -220,27 +229,6 @@
           "parts"
         ],
         "title": "Artifact",
-        "type": "object"
-      },
-      "AuthenticationInfo": {
-        "additionalProperties": {},
-        "properties": {
-          "schemes": {
-            "items": {
-              "type": "string"
-            },
-            "title": "Schemes",
-            "type": "array"
-          },
-          "credentials": {
-            "type": "string",
-            "title": "Credentials"
-          }
-        },
-        "required": [
-          "schemes"
-        ],
-        "title": "AuthenticationInfo",
         "type": "object"
       },
       "PushNotificationNotSupportedError": {
@@ -911,8 +899,12 @@
             "title": "Token",
             "type": "string"
           },
-          "authentication": {
-            "$ref": "#/$defs/AuthenticationInfo"
+          "scheme": {
+            "$ref": "#/$defs/SecurityScheme"
+          },
+          "credentials": {
+            "title": "Credentials",
+            "type": "string"
           }
         },
         "required": [
@@ -1322,7 +1314,7 @@
       },
       "MessageSendConfiguration": {
 	"properties": {
-	  "acceptedOutputModes": {{
+	  "acceptedOutputModes": {
             "items": {
               "type": "string"
             },
@@ -1345,6 +1337,7 @@
             "type": "object",
             "title": "Metadata"
           }
+        }
       },
       "TaskSendParams": {
         "properties": {
@@ -1582,6 +1575,257 @@
           }
         ],
         "title": "A2ARequest"
+      },
+      "SecurityRequirement": {
+        "$comment": "Mirrors the OpenAPI Security Requirement Object (https://swagger.io/specification/#security-requirement-object)",
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "SecurityScheme": {
+        "$comment": "Mirrors the OpenAPI Security Scheme Object (https://swagger.io/specification/#security-scheme-object)",
+        "oneOf": [
+          {
+            "$comment": "Mirrors the OpenAPI API Key Security Scheme Object (allows providing the API Key in an HTTP cookie, header or query parameter).",
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "apiKey"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "in",
+              "name",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "$comment": "Mirrors the OpenAPI HTTP Authentication Security Scheme Object.",
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "http"
+                ],
+                "type": "string"
+              },
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "$comment": "Mirrors the OpenAPI HTTP Authentication (Bearer Token) Security Scheme Object.",
+            "type": "object",
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "http"
+                ],
+                "type": "string"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "$comment": "Mirrors the OpenAPI OAuth2 Security Scheme Object.",
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "flows": {
+                "type": "object",
+                "properties": {
+                  "implicit": {
+                    "$comment": "Mirrors the OpenAPI 'implicit' OAuth Flow Object.",
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "refreshUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "scopes": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "authorizationUrl",
+                      "scopes"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "password": {
+                    "$comment": "Mirrors the OpenAPI 'password' OAuth Flow Object.",
+                    "type": "object",
+                    "properties": {
+                      "refreshUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "scopes": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "tokenUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    },
+                    "required": [
+                      "tokenUrl",
+                      "scopes"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "clientCredentials": {
+                    "$comment": "Mirrors the OpenAPI 'clientCredentials' OAuth Flow Object.",
+                    "type": "object",
+                    "properties": {
+                      "refreshUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "scopes": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "tokenUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    },
+                    "required": [
+                      "tokenUrl",
+                      "scopes"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "authorizationCode": {
+                    "$comment": "Mirrors the OpenAPI 'authorizationCode' OAuth Flow Object.",
+                    "type": "object",
+                    "properties": {
+                      "authorizationUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "refreshUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "scopes": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "tokenUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      }
+                    },
+                    "required": [
+                      "authorizationUrl",
+                      "scopes",
+                      "tokenUrl"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "type": {
+                "enum": [
+                  "oauth2"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "flows"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "$comment": "Mirrors the OpenAPI OpenID Connect Security Scheme Object.",
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri"
+              },
+              "type": {
+                "enum": [
+                  "openIdConnect"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "openIdConnectUrl",
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
This commit refactors authentication/authorization in A2A by modeling its support in the `AgentCard` _(and related API constructs)_ after OpenAPI. Here are the changes:

1. Remove `authentication` from `AgentCard` and replace it with a combination of `securitySchemes` _(analogous to OpenAPI's Security Scheme definitions)_ and `security` _(analogous to OpenAPI's Security Requirements definitions)_
2. Remove `authentication` from `PushNotificationConfig` and replaced it with `scheme` _(the Security Scheme that the push notification server uses)_ and `credentials` _(the same as `credentials` previously in `authentication`)_
3. Adds the appropriate types for describing _Security Schemes_ and _Security Requirements_

There is a follow-up PR coming that will demonstrate how to use this, and this is a **BREAKING CHANGE**.