### PR TITLE
feat: adding support for authorization at http layer (Python)

### DIFF
--- a/samples/python/common/client/client.py
+++ b/samples/python/common/client/client.py
@@ -23,13 +23,14 @@ import json
 
 
 class A2AClient:
-    def __init__(self, agent_card: AgentCard = None, url: str = None):
+    def __init__(self, agent_card: AgentCard = None, url: str = None, auth=None):
         if agent_card:
             self.url = agent_card.url
         elif url:
             self.url = url
         else:
             raise ValueError("Must provide either agent_card or url")
+        self.auth=auth
 
     async def send_task(self, payload: dict[str, Any]) -> SendTaskResponse:
         request = SendTaskRequest(params=payload)
@@ -55,9 +56,14 @@ class A2AClient:
         async with httpx.AsyncClient() as client:
             try:
                 # Image generation could take time, adding timeout
-                response = await client.post(
-                    self.url, json=request.model_dump(), timeout=30
-                )
+                if self.auth is None:
+                    response = await client.post(
+                        self.url, json=request.model_dump(), timeout=30
+                    )
+                else:
+                    response = await client.post(
+                        self.url, json=request.model_dump(), timeout=30, auth=self.auth
+                    )
                 response.raise_for_status()
                 return response.json()
             except httpx.HTTPStatusError as e:

--- a/samples/python/pyproject.toml
+++ b/samples/python/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "starlette>=0.46.1",
     "typing-extensions>=4.12.2",
     "uvicorn>=0.34.0",
+    "httpx_auth>=0.23.1",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
# Description

I re-use the code that you supplied A2A/samples/python/common as-is for my use case.

The production env in which I work is thoroughly protected: our http gateway requires request signature.

For this purpose, I had to integrate an additional package `httpx_auth` (see https://pypi.org/project/httpx-auth/ and https://github.com/Colin-b/httpx_auth)

I also needed to change client.py  to accept this auth signer: see commit diff for details. This changed code allows to go through our http gateway (tests are fine!)

Please, accept my PR so that I can keep using the reference code with no patch on my side.

**Note**: I may come back with another for the SSE part if needed when I am there in my implementation

Some similar update may have to be done for Javascript but I don't program with it.

Didier


- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [X ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).


