### PR TITLE
fix: CLI dangling task for input_required in stream

### DIFF
--- a/samples/python/common/utils/etl.py
+++ b/samples/python/common/utils/etl.py
@@ -4,6 +4,7 @@ ETL: Extract, Transform, Load
 This module contains utility functions for extracting, transforming, and loading data.
 """
 
+
 def truncate_leaves(obj: dict) -> dict:
     """
     Recursively navigate the json and truncate leaves to maximum 1000 characters
@@ -14,22 +15,22 @@ def truncate_leaves(obj: dict) -> dict:
     Returns:
         Object with truncated leaves
     """
-    
+
     if isinstance(obj, dict):
         for key, value in obj.items():
             if isinstance(value, dict):
                 truncate_leaves(value)
             elif isinstance(value, str) and len(value) > 1000:
-                obj[key] = value[:1000] + "..."
+                obj[key] = value[:1000] + '...'
             elif isinstance(value, list):
                 for item in value:
                     if isinstance(item, dict):
                         truncate_leaves(item)
                     elif isinstance(item, str) and len(item) > 1000:
-                        obj[key] = item[:1000] + "..."
+                        obj[key] = item[:1000] + '...'
                     else:
                         pass
             else:
                 pass
-    
+
     return obj

--- a/samples/python/common/utils/etl.py
+++ b/samples/python/common/utils/etl.py
@@ -1,0 +1,35 @@
+"""
+ETL: Extract, Transform, Load
+
+This module contains utility functions for extracting, transforming, and loading data.
+"""
+
+def truncate_leaves(obj: dict) -> dict:
+    """
+    Recursively navigate the json and truncate leaves to maximum 1000 characters
+
+    Args:
+        obj: The object to truncate
+
+    Returns:
+        Object with truncated leaves
+    """
+    
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if isinstance(value, dict):
+                truncate_leaves(value)
+            elif isinstance(value, str) and len(value) > 1000:
+                obj[key] = value[:1000] + "..."
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        truncate_leaves(item)
+                    elif isinstance(item, str) and len(item) > 1000:
+                        obj[key] = item[:1000] + "..."
+                    else:
+                        pass
+            else:
+                pass
+    
+    return obj

--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -147,7 +147,7 @@ async def completeTask(
     prompt: str = '\nWhat do you want to send to the agent? (:q or quit to exit)',
 ):
     prompt_response = click.prompt(prompt)
-    
+
     if prompt_response == ':q' or prompt_response == 'quit':
         return False
 
@@ -206,7 +206,9 @@ async def completeTask(
             if result.result.status.state == TaskState.INPUT_REQUIRED:
                 try:
                     # Assuming the input request prompt is the first part of the message
-                    input_request_prompt = result.result.status.message.parts[0].text
+                    input_request_prompt = result.result.status.message.parts[
+                        0
+                    ].text
                 except:
                     input_request_prompt = None
 

--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -11,17 +11,24 @@ from common.types import TaskState, Task, TextPart, FilePart, DataPart, Artifact
 from common.utils.push_notification_auth import PushNotificationReceiverAuth
 from common.utils.etl import truncate_leaves
 
+
 @click.command()
-@click.option("--agent", default="http://localhost:10000")
-@click.option("--session", default=0)
-@click.option("--history", default=False)
-@click.option("--use_push_notifications", default=False)
-@click.option("--push_notification_receiver", default="http://localhost:5000")
-async def cli(agent, session, history, use_push_notifications: bool, push_notification_receiver: str):
+@click.option('--agent', default='http://localhost:10000')
+@click.option('--session', default=0)
+@click.option('--history', default=False)
+@click.option('--use_push_notifications', default=False)
+@click.option('--push_notification_receiver', default='http://localhost:5000')
+async def cli(
+    agent,
+    session,
+    history,
+    use_push_notifications: bool,
+    push_notification_receiver: str,
+):
     card_resolver = A2ACardResolver(agent)
     card = card_resolver.get_agent_card()
 
-    print("======= Agent Card ========")
+    print('======= Agent Card ========')
     print(card.model_dump_json(exclude_none=True, indent=2))
 
     notif_receiver_parsed = urllib.parse.urlparse(push_notification_receiver)
@@ -29,17 +36,22 @@ async def cli(agent, session, history, use_push_notifications: bool, push_notifi
     notification_receiver_port = notif_receiver_parsed.port
 
     if use_push_notifications:
-        from hosts.cli.push_notification_listener import PushNotificationListener
+        from hosts.cli.push_notification_listener import (
+            PushNotificationListener,
+        )
+
         notification_receiver_auth = PushNotificationReceiverAuth()
-        await notification_receiver_auth.load_jwks(f"{agent}/.well-known/jwks.json")
+        await notification_receiver_auth.load_jwks(
+            f'{agent}/.well-known/jwks.json'
+        )
 
         push_notification_listener = PushNotificationListener(
-            host = notification_receiver_host,
-            port = notification_receiver_port,
+            host=notification_receiver_host,
+            port=notification_receiver_port,
             notification_receiver_auth=notification_receiver_auth,
         )
         push_notification_listener.start()
-        
+
     client = A2AClient(agent_card=card)
     if session == 0:
         sessionId = uuid4().hex
@@ -51,13 +63,28 @@ async def cli(agent, session, history, use_push_notifications: bool, push_notifi
 
     while continue_loop:
         taskId = uuid4().hex
-        print("=========  starting a new task ======== ")
-        continue_loop = await completeTask(client, streaming, use_push_notifications, notification_receiver_host, notification_receiver_port, taskId, sessionId)
+        print('=========  starting a new task ======== ')
+        continue_loop = await completeTask(
+            client,
+            streaming,
+            use_push_notifications,
+            notification_receiver_host,
+            notification_receiver_port,
+            taskId,
+            sessionId,
+        )
 
         if history and continue_loop:
-            print("========= history ======== ")
-            task_response = await client.get_task({"id": taskId, "historyLength": 10})
-            print(task_response.model_dump_json(include={"result": {"history": True}}, indent=2))
+            print('========= history ======== ')
+            task_response = await client.get_task(
+                {'id': taskId, 'historyLength': 10}
+            )
+            print(
+                task_response.model_dump_json(
+                    include={'result': {'history': True}}, indent=2
+                )
+            )
+
 
 def handle_artifact(artifact: Artifact) -> None:
     """
@@ -78,83 +105,94 @@ def handle_artifact(artifact: Artifact) -> None:
         for part in artifact.parts:
             if isinstance(part, FilePart):
                 if not part.file.mimeType:
-                    raise ValueError("Missing mime type for file")
-                
-                tmp_dir = os.path.join(os.getcwd(), "tmp")
+                    raise ValueError('Missing mime type for file')
+
+                tmp_dir = os.path.join(os.getcwd(), 'tmp')
                 os.makedirs(tmp_dir, exist_ok=True)
                 file_name = part.file.name
                 file_type = part.file.mimeType
-                file_extension = file_type.split("/")[1]
-                file_path = os.path.join(tmp_dir, f"{file_name}.{file_extension}")
-                
+                file_extension = file_type.split('/')[1]
+                file_path = os.path.join(
+                    tmp_dir, f'{file_name}.{file_extension}'
+                )
+
                 try:
-                    with open(file_path, "wb") as f:
+                    with open(file_path, 'wb') as f:
                         # create bytes object from base64 encoded string
                         file_bytes = base64.b64decode(part.file.bytes)
                         f.write(file_bytes)
-                    print(f"File saved to:\n{file_path}\n\n")
+                    print(f'File saved to:\n{file_path}\n\n')
                 except IOError as e:
-                    print(f"Failed to write file {file_path}: {e}")
-                    
+                    print(f'Failed to write file {file_path}: {e}')
+
             elif isinstance(part, TextPart):
-                print(f"Text content pass-through.")
+                print(f'Text content pass-through.')
             elif isinstance(part, DataPart):
-                print(f"Data content pass-through.")
+                print(f'Data content pass-through.')
             else:
-                raise ValueError(f"Unknown part type: {type(part)}")
+                raise ValueError(f'Unknown part type: {type(part)}')
     except Exception as e:
-        print(f"Error handling artifact: {e}")
+        print(f'Error handling artifact: {e}')
         raise
 
-async def completeTask(client: A2AClient, streaming, use_push_notifications: bool, notification_receiver_host: str, notification_receiver_port: int, taskId, sessionId):
+
+async def completeTask(
+    client: A2AClient,
+    streaming,
+    use_push_notifications: bool,
+    notification_receiver_host: str,
+    notification_receiver_port: int,
+    taskId,
+    sessionId,
+):
     prompt = click.prompt(
-        "\nWhat do you want to send to the agent? (:q or quit to exit)"
+        '\nWhat do you want to send to the agent? (:q or quit to exit)'
     )
-    if prompt == ":q" or prompt == "quit":
+    if prompt == ':q' or prompt == 'quit':
         return False
-    
+
     message = {
-        "role": "user",
-        "parts": [
+        'role': 'user',
+        'parts': [
             {
-                "type": "text",
-                "text": prompt,
+                'type': 'text',
+                'text': prompt,
             }
-        ]
+        ],
     }
-    
+
     file_path = click.prompt(
-        "Select a file path to attach? (press enter to skip)",
-        default="",
+        'Select a file path to attach? (press enter to skip)',
+        default='',
         show_default=False,
     )
-    if file_path and file_path.strip() != "":
-        with open(file_path, "rb") as f:
+    if file_path and file_path.strip() != '':
+        with open(file_path, 'rb') as f:
             file_content = base64.b64encode(f.read()).decode('utf-8')
             file_name = os.path.basename(file_path)
-        
-        message["parts"].append(
+
+        message['parts'].append(
             {
-                "type": "file",
-                "file": {
-                    "name": file_name,
-                    "bytes": file_content,
-                }
+                'type': 'file',
+                'file': {
+                    'name': file_name,
+                    'bytes': file_content,
+                },
             }
         )
- 
+
     payload = {
-        "id": taskId,
-        "sessionId": sessionId,
-        "acceptedOutputModes": ["text"],
-        "message": message,
+        'id': taskId,
+        'sessionId': sessionId,
+        'acceptedOutputModes': ['text'],
+        'message': message,
     }
 
     if use_push_notifications:
-        payload["pushNotification"] = {
-            "url": f"http://{notification_receiver_host}:{notification_receiver_port}/notify",            
-            "authentication": {
-                "schemes": ["bearer"],
+        payload['pushNotification'] = {
+            'url': f'http://{notification_receiver_host}:{notification_receiver_port}/notify',
+            'authentication': {
+                'schemes': ['bearer'],
             },
         }
 
@@ -162,20 +200,20 @@ async def completeTask(client: A2AClient, streaming, use_push_notifications: boo
     if streaming:
         response_stream = client.send_task_streaming(payload)
         async for result in response_stream:
-            print(f"stream event => {result.model_dump_json(exclude_none=True)}")
-        taskResult = await client.get_task({"id": taskId})
+            print(
+                f'stream event => {result.model_dump_json(exclude_none=True)}'
+            )
+        taskResult = await client.get_task({'id': taskId})
     else:
         taskResult = await client.send_task(payload)
 
         taskResultTruncatedLeaves = truncate_leaves(taskResult.model_dump())
 
-        print(f"========= Task results ========")
+        print(f'========= Task results ========')
         print(json.dumps(taskResultTruncatedLeaves, indent=2))
 
         for artifact in taskResult.result.artifacts:
             handle_artifact(artifact)
-    
-    
 
     ## if the result is that more input is required, loop again.
     state = TaskState(taskResult.result.status.state)
@@ -187,12 +225,12 @@ async def completeTask(client: A2AClient, streaming, use_push_notifications: boo
             notification_receiver_host,
             notification_receiver_port,
             taskId,
-            sessionId
+            sessionId,
         )
     else:
         ## task is complete
         return True
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     asyncio.run(cli())

--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -21,7 +21,7 @@ async def cli(agent, session, history, use_push_notifications: bool, push_notifi
     card = card_resolver.get_agent_card()
 
     print("======= Agent Card ========")
-    print(card.model_dump_json(exclude_none=True))
+    print(card.model_dump_json(exclude_none=True, indent=2))
 
     notif_receiver_parsed = urllib.parse.urlparse(push_notification_receiver)
     notification_receiver_host = notif_receiver_parsed.hostname


### PR DESCRIPTION
# Description
Currently whenever you are streaming back messages and an input is required the CLI will get deadlocked for several reasons:
- Tutorial code states that task is done whenever message for INPUT_REQUIRED is sent
- CLI has no means of handling input required for streaming

This PR resolves the problem at the CLI level enabling the CLI to handle  INPUT_REQUIRED when streaming. Additionally this PR makes streaming outputs human readbale.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)

@ToddSegal 