### PR TITLE
ci: protecting 'links' workflow against failing runs on forks

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
-    # if on repo to avoid failing runs on forks
     if: |
       github.repository == 'google/A2A'
 

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
+    # if on repo to avoid failing runs on forks
+    if: |
+      github.repository == 'google/A2A'
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Description

As per tittle, protecting workflow checking links against failing runs on forks.
Hi,

Didier

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [X ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)

