### PR TITLE
docs: tutorials/python/2-step.md fixed pip cmd

### DIFF
--- a/docs/tutorials/python/2-setup.md
+++ b/docs/tutorials/python/2-setup.md
@@ -43,7 +43,7 @@ We recommend using a virtual environment for Python projects. The A2A Python SDK
     The `a2a-python` repository contains the SDK source code. To make it and its dependencies available in your environment, run:
 
     ```bash
-    pip install -e .[dev]
+    pip install -e '.[dev]'
     ```
 
     This command installs the SDK in "editable" mode (`-e`), meaning changes to the SDK source code are immediately available. It also installs development dependencies specified in `pyproject.toml`.


### PR DESCRIPTION
Made minor fix to pip command under step titled "Install the A2A SDK and its dependencies:"

# Description

Noticed that the command in step 2 - to install a2a and it's dependencies had a slight error. Fixed it.