### PR TITLE
fix: Replace metadata type with Record<string, any> equivalent

### DIFF
--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -254,9 +254,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 },
                 "name": {
@@ -373,9 +372,8 @@
             "description": "Represents a structured data segment within a message part.",
             "properties": {
                 "data": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "Structured data content",
-                    "properties": {},
                     "type": "object"
                 },
                 "kind": {
@@ -384,9 +382,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "Optional metadata associated with the part.",
-                    "properties": {},
                     "type": "object"
                 }
             },
@@ -430,9 +427,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "Optional metadata associated with the part.",
-                    "properties": {},
                     "type": "object"
                 }
             },
@@ -939,9 +935,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 },
                 "parts": {
@@ -1012,9 +1007,8 @@
                     "description": "The message being sent to the server"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 }
             },
@@ -1064,9 +1058,8 @@
             "description": "Base properties common to all message parts.",
             "properties": {
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "Optional metadata associated with the part.",
-                    "properties": {},
                     "type": "object"
                 }
             },
@@ -1391,9 +1384,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 },
                 "status": {
@@ -1434,9 +1426,8 @@
                     "type": "boolean"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 },
                 "taskId": {
@@ -1460,8 +1451,7 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
-                    "properties": {},
+                    "additionalProperties": {},
                     "type": "object"
                 }
             },
@@ -1545,8 +1535,7 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
-                    "properties": {},
+                    "additionalProperties": {},
                     "type": "object"
                 }
             },
@@ -1639,9 +1628,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "extension metadata",
-                    "properties": {},
                     "type": "object"
                 },
                 "status": {
@@ -1671,9 +1659,8 @@
                     "type": "string"
                 },
                 "metadata": {
-                    "additionalProperties": true,
+                    "additionalProperties": {},
                     "description": "Optional metadata associated with the part.",
-                    "properties": {},
                     "type": "object"
                 },
                 "text": {

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -128,7 +128,9 @@ export interface Task {
   /** collection of artifacts created by the agent. */
   artifacts?: Artifact[];
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
   /** event type */
   kind: "task";
 }
@@ -158,7 +160,9 @@ export interface TaskStatusUpdateEvent {
   /** indicates the end of the event stream */
   final: boolean;
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** sent by server during sendStream or subscribe requests */
@@ -176,14 +180,18 @@ export interface TaskArtifactUpdateEvent {
   /** Indicates if this is the last chunk of the artifact */
   lastChunk?: boolean;
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** Parameters containing only a task ID, used for simple task operations. */
 export interface TaskIdParams {
   /** task id */
   id: string;
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** Parameters for querying a task, including optional history length. */
@@ -211,7 +219,9 @@ export interface MessageSendParams {
   /** Send message configuration */
   configuration?: MessageSendConfiguration;
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** Represents the possible states of a Task. */
@@ -238,7 +248,9 @@ export interface Artifact {
   /** artifact parts */
   parts: Part[];
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** Represents a single message exchanged between user and agent. */
@@ -248,7 +260,9 @@ export interface Message {
   /** message content */
   parts: Part[];
   /** extension metadata */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
   /** identifier created by the message creator*/
   messageId: string;
   /** identifier of task the message is related to */
@@ -262,7 +276,9 @@ export interface Message {
 /** Base properties common to all message parts. */
 export interface PartBase {
   /** Optional metadata associated with the part. */
-  metadata?: object;
+  metadata?: {
+    [key: string]: any;
+  };
 }
 
 /** Represents a text segment within parts.*/
@@ -308,7 +324,9 @@ export interface DataPart extends PartBase {
   kind: "data";
   /** Structured data content 
   */
-  data: object;
+  data: {
+    [key: string]: any;
+  };
 }
 
 /** Represents a part of a message, which can be text, a file, or structured data. */


### PR DESCRIPTION
# Description

metadata was previously represented as metadata?: Record<string, any>, to imply this is a key-value pair. However defining in this format creates a new type in json-schema. To address the json schema generation, we used metadata?: object which fixes the generation issue. However, documenting metadata?: object in specification implies that metadata can accept more than just key-value pairs.

To address this, spec will still have metadata?: Record<string, any>, but we will use equivalent `{ [key: string]: any;}` to represent this attribute in types. 