### PR TITLE
fix: Split OAuth flows into different types

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,0 +1,11 @@
+AError
+nas
+ngenerated
+nin
+npurposes
+nrequires
+nskill
+nstandard
+nsupports
+nused
+tagwords

--- a/specification/json/a2a.json
+++ b/specification/json/a2a.json
@@ -303,6 +303,36 @@
             ],
             "type": "object"
         },
+        "AuthorizationCodeOAuthFlow": {
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "authorizationUrl": {
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS",
+                    "type": "string"
+                },
+                "refreshUrl": {
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS.",
+                    "type": "string"
+                },
+                "scopes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short\ndescription for it. The map MAY be empty.",
+                    "type": "object"
+                },
+                "tokenUrl": {
+                    "description": "The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard\nrequires the use of TLS.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "authorizationUrl",
+                "scopes",
+                "tokenUrl"
+            ],
+            "type": "object"
+        },
         "CancelTaskRequest": {
             "description": "JSON-RPC request model for the 'tasks/cancel' method.",
             "properties": {
@@ -369,6 +399,31 @@
             "required": [
                 "jsonrpc",
                 "result"
+            ],
+            "type": "object"
+        },
+        "ClientCredentialsOAuthFlow": {
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "refreshUrl": {
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS.",
+                    "type": "string"
+                },
+                "scopes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short\ndescription for it. The map MAY be empty.",
+                    "type": "object"
+                },
+                "tokenUrl": {
+                    "description": "The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard\nrequires the use of TLS.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "scopes",
+                "tokenUrl"
             ],
             "type": "object"
         },
@@ -667,6 +722,31 @@
             "required": [
                 "scheme",
                 "type"
+            ],
+            "type": "object"
+        },
+        "ImplicitOAuthFlow": {
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "authorizationUrl": {
+                    "description": "The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS",
+                    "type": "string"
+                },
+                "refreshUrl": {
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS.",
+                    "type": "string"
+                },
+                "scopes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short\ndescription for it. The map MAY be empty.",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "authorizationUrl",
+                "scopes"
             ],
             "type": "object"
         },
@@ -1115,54 +1195,23 @@
             ],
             "type": "object"
         },
-        "OAuthFlow": {
-            "description": "Configuration details for a supported OAuth Flow",
-            "properties": {
-                "authorizationUrl": {
-                    "description": "The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS",
-                    "type": "string"
-                },
-                "refreshUrl": {
-                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS.",
-                    "type": "string"
-                },
-                "scopes": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short\ndescription for it. The map MAY be empty.",
-                    "type": "object"
-                },
-                "tokenUrl": {
-                    "description": "The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard\nrequires the use of TLS.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "authorizationUrl",
-                "refreshUrl",
-                "scopes",
-                "tokenUrl"
-            ],
-            "type": "object"
-        },
         "OAuthFlows": {
             "description": "Allows configuration of the supported OAuth Flows",
             "properties": {
                 "authorizationCode": {
-                    "$ref": "#/definitions/OAuthFlow",
+                    "$ref": "#/definitions/AuthorizationCodeOAuthFlow",
                     "description": "Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0."
                 },
                 "clientCredentials": {
-                    "$ref": "#/definitions/OAuthFlow",
+                    "$ref": "#/definitions/ClientCredentialsOAuthFlow",
                     "description": "Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0"
                 },
                 "implicit": {
-                    "$ref": "#/definitions/OAuthFlow",
+                    "$ref": "#/definitions/ImplicitOAuthFlow",
                     "description": "Configuration for the OAuth Implicit flow"
                 },
                 "password": {
-                    "$ref": "#/definitions/OAuthFlow",
+                    "$ref": "#/definitions/PasswordOAuthFlow",
                     "description": "Configuration for the OAuth Resource Owner Password flow"
                 }
             },
@@ -1213,6 +1262,31 @@
                     "type": "object"
                 }
             },
+            "type": "object"
+        },
+        "PasswordOAuthFlow": {
+            "description": "Configuration details for a supported OAuth Flow",
+            "properties": {
+                "refreshUrl": {
+                    "description": "The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2\nstandard requires the use of TLS.",
+                    "type": "string"
+                },
+                "scopes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "The available scopes for the OAuth2 security scheme. A map between the scope name and a short\ndescription for it. The map MAY be empty.",
+                    "type": "object"
+                },
+                "tokenUrl": {
+                    "description": "The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard\nrequires the use of TLS.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "scopes",
+                "tokenUrl"
+            ],
             "type": "object"
         },
         "PushNotificationAuthenticationInfo": {

--- a/types/src/types.ts
+++ b/types/src/types.ts
@@ -402,17 +402,17 @@ export interface OpenIdConnectSecurityScheme extends SecuritySchemeBase {
 /** Allows configuration of the supported OAuth Flows */
 export interface OAuthFlows {
   /** Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0. */
-  authorizationCode?: OAuthFlow;
+  authorizationCode?: AuthorizationCodeOAuthFlow;
   /** Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0 */
-  clientCredentials?: OAuthFlow;
+  clientCredentials?: ClientCredentialsOAuthFlow;
   /** Configuration for the OAuth Implicit flow */
-  implicit?: OAuthFlow;
+  implicit?: ImplicitOAuthFlow;
   /** Configuration for the OAuth Resource Owner Password flow */
-  password?: OAuthFlow;
+  password?: PasswordOAuthFlow;
 }
 
 /** Configuration details for a supported OAuth Flow */
-export interface OAuthFlow {
+export interface AuthorizationCodeOAuthFlow {
   /** 
    * The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2
    * standard requires the use of TLS
@@ -427,7 +427,64 @@ export interface OAuthFlow {
    * The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2
    * standard requires the use of TLS.
    */
-  refreshUrl: string;
+  refreshUrl?: string;
+  /**
+   * The available scopes for the OAuth2 security scheme. A map between the scope name and a short
+   * description for it. The map MAY be empty.
+   */
+  scopes: { [name: string]: string };
+}
+
+/** Configuration details for a supported OAuth Flow */
+export interface ClientCredentialsOAuthFlow {
+  /**
+   * The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard
+   * requires the use of TLS.
+   */
+  tokenUrl: string;
+  /**
+   * The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2
+   * standard requires the use of TLS.
+   */
+  refreshUrl?: string;
+  /**
+   * The available scopes for the OAuth2 security scheme. A map between the scope name and a short
+   * description for it. The map MAY be empty.
+   */
+  scopes: { [name: string]: string };
+}
+
+/** Configuration details for a supported OAuth Flow */
+export interface ImplicitOAuthFlow {
+  /** 
+   * The authorization URL to be used for this flow. This MUST be in the form of a URL. The OAuth2
+   * standard requires the use of TLS
+   */
+  authorizationUrl: string;
+  /**
+   * The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2
+   * standard requires the use of TLS.
+   */
+  refreshUrl?: string;
+  /**
+   * The available scopes for the OAuth2 security scheme. A map between the scope name and a short
+   * description for it. The map MAY be empty.
+   */
+  scopes: { [name: string]: string };
+}
+
+/** Configuration details for a supported OAuth Flow */
+export interface PasswordOAuthFlow {
+  /**
+   * The token URL to be used for this flow. This MUST be in the form of a URL. The OAuth2 standard
+   * requires the use of TLS.
+   */
+  tokenUrl: string;
+  /**
+   * The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL. The OAuth2
+   * standard requires the use of TLS.
+   */
+  refreshUrl?: string;
   /**
    * The available scopes for the OAuth2 security scheme. A map between the scope name and a short
    * description for it. The map MAY be empty.


### PR DESCRIPTION
# Description

Different fields are required/allowed for different OAuth flow types. Represent this by splitting flows into different types with the appropriate properties.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/google/A2A/blob/main/CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [X] Appropriate docs were updated (if necessary)
