### PR TITLE
fix: Update tutorial with 0.2.0 changes

### DIFF
--- a/docs/tutorials/python/2-setup.md
+++ b/docs/tutorials/python/2-setup.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.10 or higher.
+- Python 3.13 or higher.
 - Access to a terminal or command prompt.
 - Git, for cloning the repository.
 - A code editor (e.g., VS Code) is recommended.

--- a/docs/tutorials/python/3-agent-skills-and-card.md
+++ b/docs/tutorials/python/3-agent-skills-and-card.md
@@ -43,7 +43,6 @@ Key attributes of an `AgentCard` (defined in `a2a.types`):
 - `name`, `description`, `version`: Basic identity information.
 - `url`: The endpoint where the A2A service can be reached.
 - `capabilities`: Specifies supported A2A features like `streaming` or `pushNotifications`.
-- `authentication`: Details on how clients should authenticate.
 - `defaultInputModes` / `defaultOutputModes`: Default MIME types for the agent.
 - `skills`: A list of `AgentSkill` objects that the agent offers.
 
@@ -59,9 +58,8 @@ The `helloworld` example defines its Agent Card like this:
         version='1.0.0',
         defaultInputModes=['text'],
         defaultOutputModes=['text'],
-        capabilities=AgentCapabilities(), # Basic capabilities
+        capabilities=AgentCapabilities(streaming=True), # Basic capabilities
         skills=[skill], # Includes the skill defined above
-        authentication=AgentAuthentication(schemes=['public']), # No auth needed
     )
 # ...
 ```

--- a/docs/tutorials/python/5-start-server.md
+++ b/docs/tutorials/python/5-start-server.md
@@ -19,8 +19,7 @@ from a2a.types import (
     # ... other imports ...
     AgentCard,
     AgentSkill,
-    AgentCapabilities,
-    AgentAuthentication,
+    AgentCapabilities
     # ...
 )
 import uvicorn
@@ -42,9 +41,8 @@ if __name__ == '__main__':
         version='1.0.0',
         defaultInputModes=['text'],
         defaultOutputModes=['text'],
-        capabilities=AgentCapabilities(),
+        capabilities=AgentCapabilities(streaming=True),
         skills=[skill],
-        authentication=AgentAuthentication(schemes=['public']),
     )
 
     # 1. Request Handler


### PR DESCRIPTION
- requires Python 3.13
- AgentAuthentication has been removed from the SDK with the introduction of SecuritySchemes