### PR TITLE
ci: Add dispatch-a2a-update Action for when a2a.json is updated

### DIFF
--- a/.github/workflows/dispatch-a2a-update.yml
+++ b/.github/workflows/dispatch-a2a-update.yml
@@ -1,0 +1,25 @@
+name: Dispatch A2A JSON Update
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "specification/json/a2a.json"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch repository_dispatch to a2a-python
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.A2A_BOT_PAT }}
+          repository: google/a2a-python
+          event-type: a2a_json_update
+          client-payload: |
+            {
+              "ref": "${{ github.ref }}",
+              "sha": "${{ github.sha }}",
+              "message": "Updated 'specification/json/a2a.json' in google/A2A"
+            }


### PR DESCRIPTION
- This allows triggering of the types.py generation in google/a2a-python
- Requirement for https://github.com/google/a2a-python/pull/92